### PR TITLE
Decrypt no longer requires a mutable self reference

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -94,7 +94,7 @@ pub trait DocumentOps {
     ///
     /// # Returns
     /// `Result<DocumentDecryptResult>` Includes metadata about the provided document as well as the decrypted document bytes.
-    fn document_decrypt(&mut self, encrypted_document: &[u8]) -> Result<DocumentDecryptResult>;
+    fn document_decrypt(&self, encrypted_document: &[u8]) -> Result<DocumentDecryptResult>;
 
     /// Update a document name to a new value or clear its value.
     ///
@@ -198,12 +198,12 @@ impl DocumentOps for crate::IronOxide {
         ))
     }
 
-    fn document_decrypt(&mut self, encrypted_document: &[u8]) -> Result<DocumentDecryptResult> {
+    fn document_decrypt(&self, encrypted_document: &[u8]) -> Result<DocumentDecryptResult> {
         let mut rt = Runtime::new().unwrap();
 
         rt.block_on(document_api::decrypt_document(
             self.device.auth(),
-            &mut self.recrypt,
+            &self.recrypt,
             self.device.private_device_key(),
             encrypted_document,
         ))

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -511,7 +511,7 @@ pub fn document_update_bytes<'a, CR: rand::CryptoRng + rand::RngCore>(
 //that was decrypted along with it's decrypted bytes.
 pub fn decrypt_document<'a, CR: rand::CryptoRng + rand::RngCore>(
     auth: &'a RequestAuth,
-    recrypt: &'a mut Recrypt<Sha256, Ed25519, RandomBytes<CR>>,
+    recrypt: &'a Recrypt<Sha256, Ed25519, RandomBytes<CR>>,
     device_private_key: &'a PrivateKey,
     encrypted_doc: &'a [u8],
 ) -> impl Future<Item = DocumentDecryptResult, Error = IronOxideErr> + 'a {


### PR DESCRIPTION
This is because recrypt's `decrypt` does not require a mutable reference. 