### PR TITLE
[#15] Encrypt via policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 before_cache:
   - rm -rf /home/travis/.cargo/registry
 rust:
-  - 1.34.1
+  - 1.36.0
 branches:
   only:
     - master

--- a/src/document.rs
+++ b/src/document.rs
@@ -3,13 +3,13 @@ pub use crate::internal::document_api::{
     DocumentEncryptResult, DocumentListMeta, DocumentListResult, DocumentMetadataResult,
     UserOrGroup, VisibleGroup, VisibleUser,
 };
-use crate::policy::*;
 use crate::{
     internal::{
         document_api::{self, DocumentId, DocumentName},
         group_api::GroupId,
         user_api::UserId,
     },
+    policy::*,
     Result,
 };
 use itertools::{Either, EitherOrBoth, Itertools};

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -1,6 +1,6 @@
 use crate::crypto::aes::AesEncryptedValue;
-use crate::document::PolicyGrant;
 use crate::internal::document_api::requests::UserOrGroupWithKey;
+use crate::policy::PolicyGrant;
 use crate::{
     crypto::{aes, transform},
     internal::{
@@ -451,7 +451,6 @@ pub fn encrypt_document<'a, CR: rand::CryptoRng + rand::RngCore>(
             } else {
                 [&users_with_key[..], &groups_with_key[..]].concat()
             };
-            dbg!(&maybe_policy_res);
             let (policy_errs, applied_policy_grants) = match maybe_policy_res {
                 None => (vec![], vec![]),
                 Some(res) => process_policy(&res),

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -1,7 +1,6 @@
 use crate::crypto::aes::AesEncryptedValue;
 use crate::document::PolicyGrant;
 use crate::internal::document_api::requests::UserOrGroupWithKey;
-use crate::internal::document_api::UserOrGroup::User;
 use crate::{
     crypto::{aes, transform},
     internal::{

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -1,22 +1,23 @@
-use crate::crypto::aes::AesEncryptedValue;
-use crate::internal::document_api::requests::UserOrGroupWithKey;
-use crate::policy::PolicyGrant;
 use crate::{
-    crypto::{aes, transform},
+    crypto::{
+        aes::{self, AesEncryptedValue},
+        transform,
+    },
     internal::{
         self,
+        document_api::requests::UserOrGroupWithKey,
         group_api::{GroupId, GroupName},
         user_api::UserId,
         validate_id, validate_name, IronOxideErr, PrivateKey, PublicKey, RequestAuth, WithKey,
     },
+    policy::PolicyGrant,
 };
 use chrono::{DateTime, Utc};
 use futures::prelude::*;
 use hex::encode;
 use itertools::{Either, Itertools};
 use rand::{self, CryptoRng, RngCore};
-use recrypt::api::Plaintext;
-use recrypt::prelude::*;
+use recrypt::{api::Plaintext, prelude::*};
 pub use requests::policy_get::PolicyResult;
 use requests::{
     document_create,
@@ -834,8 +835,7 @@ fn process_policy(
 mod tests {
     use crate::internal::test::contains;
     use base64::decode;
-    use galvanic_assert::matchers::collection::*;
-    use galvanic_assert::matchers::*;
+    use galvanic_assert::matchers::{collection::*, *};
 
     use super::*;
 

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -434,9 +434,7 @@ pub fn encrypt_document<'a, CR: rand::CryptoRng + rand::RngCore>(
     internal::user_api::get_user_keys(auth, user_grants)
         .join4(
             internal::group_api::get_group_keys(auth, group_grants),
-            policy_grant.map_or(None, |p| {
-                Some(requests::policy_get::policy_get_request(auth, p))
-            }),
+            policy_grant.map(|p| requests::policy_get::policy_get_request(auth, p)),
             aes::encrypt_future(rng, &plaintext.to_vec(), *doc_sym_key.bytes()),
         )
         .and_then(move |(users, groups, maybe_policy_res, encrypted_doc)| {

--- a/src/internal/document_api/requests.rs
+++ b/src/internal/document_api/requests.rs
@@ -217,8 +217,9 @@ pub mod policy_get {
     use super::*;
 
     pub struct PolicyResult {
-        users: Vec<UserOrGroupWithKey>,
-        groups: Vec<UserOrGroupWithKey>,
+        grants: Vec<UserOrGroupWithKey>,
+        invalid_users: Vec<UserId>,
+        invalid_groups: Vec<GroupId>,
     }
 
     pub fn policy_get_request(

--- a/src/internal/document_api/requests.rs
+++ b/src/internal/document_api/requests.rs
@@ -228,22 +228,14 @@ pub mod document_create {
 
 pub mod policy_get {
     use super::*;
+    use crate::document::{Category, DataSubject, PolicyGrant, Sensitivity, SubstituteId};
 
     #[derive(Deserialize, Debug, Clone)]
     #[serde(rename_all = "camelCase")]
     pub struct PolicyResult {
         pub(crate) users_and_groups: Vec<UserOrGroupWithKey>,
-        pub(crate) invalid_users: Vec<UserId>,
-        pub(crate) invalid_groups: Vec<GroupId>,
+        pub(crate) invalid_users_and_groups: Vec<UserOrGroup>,
     }
-
-    impl PolicyResult {
-        pub fn user_or_groups(&self) -> &[UserOrGroupWithKey] {
-            &self.users_and_groups
-        }
-    }
-
-    use crate::document::{Category, DataSubject, PolicyGrant, Sensitivity, SubstituteId};
 
     pub fn policy_get_request(
         auth: &RequestAuth,

--- a/src/internal/document_api/requests.rs
+++ b/src/internal/document_api/requests.rs
@@ -244,15 +244,12 @@ pub mod policy_get {
     }
 
     use crate::document::{Category, DataSubject, PolicyGrant, Sensitivity, SubstituteId};
-    use futures::future::IntoFuture;
-    use itertools::{fold, Itertools};
 
     pub fn policy_get_request(
         auth: &RequestAuth,
         policy_grant: &PolicyGrant,
     ) -> impl Future<Item = PolicyResult, Error = IronOxideErr> {
         dbg!(&policy_grant);
-        let url_with_query_params = "policies";
         let query_params: Vec<(String, String)> = [
             policy_grant
                 .category()

--- a/src/internal/document_api/requests.rs
+++ b/src/internal/document_api/requests.rs
@@ -213,6 +213,26 @@ pub mod document_create {
     }
 }
 
+pub mod policy_get {
+    use super::*;
+
+    pub struct PolicyResult {
+        users: Vec<UserOrGroupWithKey>,
+        groups: Vec<UserOrGroupWithKey>,
+    }
+
+    pub fn policy_get_request(
+        auth: &RequestAuth,
+        classification: Option<String>,
+        sensitivity: Option<String>,
+        data_subject: Option<String>,
+        substitute_id: Option<String>,
+    ) -> PolicyResult {
+        unimplemented!()
+    }
+
+}
+
 pub mod document_update {
     use super::*;
 

--- a/src/internal/document_api/requests.rs
+++ b/src/internal/document_api/requests.rs
@@ -262,7 +262,7 @@ pub mod policy_get {
                 .map(|d| (DataSubject::QUERY_PARAM.to_string(), d.0.clone())),
             policy_grant
                 .substitute_id()
-                .map(|s| (SubstituteId::QUERY_PARAM.to_string(), s.0.clone())),
+                .map(|SubstituteId(UserId(u))| (SubstituteId::QUERY_PARAM.to_string(), u.clone())),
         ]
         .to_vec()
         .into_iter()

--- a/src/internal/document_api/requests.rs
+++ b/src/internal/document_api/requests.rs
@@ -228,7 +228,7 @@ pub mod document_create {
 
 pub mod policy_get {
     use super::*;
-    use crate::document::{Category, DataSubject, PolicyGrant, Sensitivity, SubstituteId};
+    use crate::policy::{Category, DataSubject, PolicyGrant, Sensitivity, SubstituteId};
 
     #[derive(Deserialize, Debug, Clone)]
     #[serde(rename_all = "camelCase")]
@@ -241,7 +241,6 @@ pub mod policy_get {
         auth: &RequestAuth,
         policy_grant: &PolicyGrant,
     ) -> impl Future<Item = PolicyResult, Error = IronOxideErr> {
-        dbg!(&policy_grant);
         let query_params: Vec<(String, String)> = [
             policy_grant
                 .category()

--- a/src/internal/group_api/mod.rs
+++ b/src/internal/group_api/mod.rs
@@ -32,6 +32,11 @@ impl GroupId {
     pub fn id(&self) -> &String {
         &self.0
     }
+
+    /// Create a GroupId from a string with no validation. Useful for ids coming back from the web service.
+    pub fn unsafe_from_string(id: String) -> GroupId {
+        GroupId(id)
+    }
 }
 impl TryFrom<String> for GroupId {
     type Error = IronOxideErr;

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -103,9 +103,6 @@ quick_error! {
         NotGroupAdmin(group_id:group_api::GroupId) {
             display("You're are not an administrator of group '{}'", group_id.0)
         }
-        InvalidPolicy {
-            display("A policy must specify one or more of category, sensitivity, data_subject, substitute_id")
-        }
     }
 }
 
@@ -151,7 +148,10 @@ pub fn validate_id(id: &str, id_type: &str) -> Result<String, IronOxideErr> {
     }
 }
 
-pub fn validate_simple_policy_id(id: &str, id_type: &str) -> Result<String, IronOxideErr> {
+pub fn validate_simple_policy_field_id(
+    field_id: &str,
+    field_type: &str,
+) -> Result<String, IronOxideErr> {
     let simple_policy_field_regex = Regex::new("^[A-Za-z0-9_-]+$").expect("regex is valid");
     let trimmed_id = id.trim();
     if trimmed_id.is_empty() || trimmed_id.len() > NAME_AND_ID_MAX_LEN {
@@ -709,15 +709,15 @@ pub(crate) mod test {
     fn validate_simple_policy_id_good() {
         let name_type = "name_type";
         let id = "abc-123";
-        let result = validate_simple_policy_id(id, name_type);
+        let result = validate_simple_policy_field_id(id, name_type);
         assert_that!(&result, is_variant!(Ok));
 
         let id = "SIMPLE_2";
-        let result = validate_simple_policy_id(id, name_type);
+        let result = validate_simple_policy_field_id(id, name_type);
         assert_that!(&result, is_variant!(Ok));
 
         let id = "LOTS-O-CHARS_012345678901234567890123456789012345678901234567890123456789012345678901234567890123456";
-        let result = validate_simple_policy_id(id, name_type);
+        let result = validate_simple_policy_field_id(id, name_type);
         assert_that!(&result, is_variant!(Ok))
     }
 
@@ -727,7 +727,7 @@ pub(crate) mod test {
 
         // very limited special chars
         let invalid = "abc!123";
-        let result = validate_simple_policy_id(invalid, name_type);
+        let result = validate_simple_policy_field_id(invalid, name_type);
         assert_that!(&result, is_variant!(Err));
         let validation_error = result.unwrap_err();
         assert_that!(
@@ -737,7 +737,7 @@ pub(crate) mod test {
 
         //no unicode
         let invalid = "❤HEART❤";
-        let result = validate_simple_policy_id(invalid, name_type);
+        let result = validate_simple_policy_field_id(invalid, name_type);
         assert_that!(&result, is_variant!(Err));
         let validation_error = result.unwrap_err();
         assert_that!(
@@ -747,7 +747,7 @@ pub(crate) mod test {
 
         // no spaces
         let invalid = "spaces not allowed";
-        let result = validate_simple_policy_id(invalid, name_type);
+        let result = validate_simple_policy_field_id(invalid, name_type);
         assert_that!(&result, is_variant!(Err));
         let validation_error = result.unwrap_err();
         assert_that!(
@@ -760,7 +760,7 @@ pub(crate) mod test {
     fn validate_simple_policy_id_invalid_length() {
         let name_type = "name_type";
         let invalid = "too many chars 012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";
-        let result = validate_simple_policy_id(invalid, name_type);
+        let result = validate_simple_policy_field_id(invalid, name_type);
         assert_that!(&result, is_variant!(Err));
         let validation_error = result.unwrap_err();
         assert_that!(

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -53,6 +53,7 @@ pub enum RequestErrorCode {
     DocumentUpdate,
     DocumentGrantAccess,
     DocumentRevokeAccess,
+    PolicyGet,
 }
 
 quick_error! {
@@ -101,6 +102,9 @@ quick_error! {
         ///The operation failed because the accessing user was not a group admin, but must be for the operation to work.
         NotGroupAdmin(group_id:group_api::GroupId) {
             display("You're are not an administrator of group '{}'", group_id.0)
+        }
+        InvalidPolicy {
+            display("A policy must specify one or more of category, sensitivity, data_subject, substitute_id")
         }
     }
 }
@@ -525,7 +529,7 @@ impl TryFrom<&str> for Password {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct WithKey<T> {
     pub(crate) id: T,
     pub(crate) public_key: PublicKey,

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -148,27 +148,6 @@ pub fn validate_id(id: &str, id_type: &str) -> Result<String, IronOxideErr> {
     }
 }
 
-pub fn validate_simple_policy_field_id(
-    field_id: &str,
-    field_type: &str,
-) -> Result<String, IronOxideErr> {
-    let simple_policy_field_regex = Regex::new("^[A-Za-z0-9_-]+$").expect("regex is valid");
-    let trimmed_id = field_id.trim();
-    if trimmed_id.is_empty() || trimmed_id.len() > NAME_AND_ID_MAX_LEN {
-        Err(IronOxideErr::ValidationError(
-            field_type.to_string(),
-            format!("'{}' must have length between 1 and 100", trimmed_id),
-        ))
-    } else if !simple_policy_field_regex.is_match(trimmed_id) {
-        Err(IronOxideErr::ValidationError(
-            field_type.to_string(),
-            format!("'{}' contains invalid characters", trimmed_id),
-        ))
-    } else {
-        Ok(trimmed_id.to_string())
-    }
-}
-
 /// Validate that the provided document/group name is valid. Ensures that the length of
 /// the name is between 1-100 characters. Also takes the readable type of the name for
 /// usage within any resulting error messages.
@@ -703,71 +682,6 @@ pub(crate) mod test {
             is_variant!(IronOxideErr::ValidationError)
         );
         assert_that!(&format!("{}", validation_error), contains(name_type));
-    }
-
-    #[test]
-    fn validate_simple_policy_id_good() {
-        let name_type = "name_type";
-        let id = "abc-123";
-        let result = validate_simple_policy_field_id(id, name_type);
-        assert_that!(&result, is_variant!(Ok));
-
-        let id = "SIMPLE_2";
-        let result = validate_simple_policy_field_id(id, name_type);
-        assert_that!(&result, is_variant!(Ok));
-
-        let id = "LOTS-O-CHARS_012345678901234567890123456789012345678901234567890123456789012345678901234567890123456";
-        let result = validate_simple_policy_field_id(id, name_type);
-        assert_that!(&result, is_variant!(Ok))
-    }
-
-    #[test]
-    fn validate_simple_policy_id_invalid_chars() {
-        let name_type = "name_type";
-
-        // very limited special chars
-        let invalid = "abc!123";
-        let result = validate_simple_policy_field_id(invalid, name_type);
-        assert_that!(&result, is_variant!(Err));
-        let validation_error = result.unwrap_err();
-        assert_that!(
-            &validation_error,
-            is_variant!(IronOxideErr::ValidationError)
-        );
-
-        //no unicode
-        let invalid = "❤HEART❤";
-        let result = validate_simple_policy_field_id(invalid, name_type);
-        assert_that!(&result, is_variant!(Err));
-        let validation_error = result.unwrap_err();
-        assert_that!(
-            &validation_error,
-            is_variant!(IronOxideErr::ValidationError)
-        );
-
-        // no spaces
-        let invalid = "spaces not allowed";
-        let result = validate_simple_policy_field_id(invalid, name_type);
-        assert_that!(&result, is_variant!(Err));
-        let validation_error = result.unwrap_err();
-        assert_that!(
-            &validation_error,
-            is_variant!(IronOxideErr::ValidationError)
-        );
-    }
-
-    #[test]
-    fn validate_simple_policy_id_invalid_length() {
-        let name_type = "name_type";
-        let invalid = "too many chars 012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";
-        let result = validate_simple_policy_field_id(invalid, name_type);
-        assert_that!(&result, is_variant!(Err));
-        let validation_error = result.unwrap_err();
-        assert_that!(
-            &validation_error,
-            is_variant!(IronOxideErr::ValidationError)
-        );
-        assert_that!(&format!("{}", validation_error), contains("100"));
     }
 
     #[test]

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -153,15 +153,15 @@ pub fn validate_simple_policy_field_id(
     field_type: &str,
 ) -> Result<String, IronOxideErr> {
     let simple_policy_field_regex = Regex::new("^[A-Za-z0-9_-]+$").expect("regex is valid");
-    let trimmed_id = id.trim();
+    let trimmed_id = field_id.trim();
     if trimmed_id.is_empty() || trimmed_id.len() > NAME_AND_ID_MAX_LEN {
         Err(IronOxideErr::ValidationError(
-            id_type.to_string(),
+            field_type.to_string(),
             format!("'{}' must have length between 1 and 100", trimmed_id),
         ))
     } else if !simple_policy_field_regex.is_match(trimmed_id) {
         Err(IronOxideErr::ValidationError(
-            id_type.to_string(),
+            field_type.to_string(),
             format!("'{}' contains invalid characters", trimmed_id),
         ))
     } else {

--- a/src/internal/rest.rs
+++ b/src/internal/rest.rs
@@ -272,16 +272,17 @@ impl<'a> IronCoreRequest<'a> {
             .iter()
             .fold(builder, |build, body| build.json(body));
 
-        builder
-            .headers(DEFAULT_HEADERS.clone())
-            .headers(headers)
-            .send()
+        let req = builder.headers(DEFAULT_HEADERS.clone()).headers(headers);
+        dbg!(&req);
+        req.send()
             //Parse the body content into bytes
             .and_then(|res| {
+                dbg!(&res);
                 let status_code = res.status();
-                res.into_body()
-                    .concat2()
-                    .map(move |body| (status_code, body))
+                res.into_body().concat2().map(move |body| {
+                    dbg!(&body);
+                    (status_code, body)
+                })
             })
             //Now make the error type into the IronOxideErr and run the resp_handler which was passed to us.
             .then(move |resp| {

--- a/src/internal/rest.rs
+++ b/src/internal/rest.rs
@@ -122,10 +122,11 @@ impl<'a> IronCoreRequest<'a> {
         error_code: RequestErrorCode,
         auth: &Authorization,
     ) -> impl Future<Item = B, Error = IronOxideErr> {
-        self.request(
+        self.request::<A, _, String, _>(
             relative_url,
             Method::POST,
             Some(body),
+            None,
             error_code,
             auth.to_header(),
             move |server_resp| IronCoreRequest::deserialize_body(server_resp, error_code),
@@ -141,10 +142,11 @@ impl<'a> IronCoreRequest<'a> {
         error_code: RequestErrorCode,
         auth: &Authorization,
     ) -> impl Future<Item = B, Error = IronOxideErr> {
-        self.request(
+        self.request::<A, _, String, _>(
             relative_url,
             Method::PUT,
             Some(body),
+            None,
             error_code,
             auth.to_header(),
             move |server_resp| IronCoreRequest::deserialize_body(server_resp, error_code),
@@ -160,10 +162,32 @@ impl<'a> IronCoreRequest<'a> {
         auth: &Authorization,
     ) -> impl Future<Item = A, Error = IronOxideErr> {
         //A little lie here, String isn't actually the body type as it's unused
-        self.request::<String, _, _>(
+        self.request::<String, _, String, _>(
             relative_url,
             Method::GET,
             None,
+            None,
+            error_code,
+            auth.to_header(),
+            move |server_resp| IronCoreRequest::deserialize_body(server_resp, error_code),
+        )
+    }
+
+    ///GET the resource at relative_url using auth for authorization.
+    ///If the request fails a RequestError will be raised.
+    pub fn get_with_query_params<A: DeserializeOwned>(
+        &self,
+        relative_url: &str,
+        query_params: &[(String, String)],
+        error_code: RequestErrorCode,
+        auth: &Authorization,
+    ) -> impl Future<Item = A, Error = IronOxideErr> {
+        //A little lie here, String isn't actually the body type as it's unused
+        self.request::<String, _, [(String, String)], _>(
+            relative_url,
+            Method::GET,
+            None,
+            Some(query_params),
             error_code,
             auth.to_header(),
             move |server_resp| IronCoreRequest::deserialize_body(server_resp, error_code),
@@ -178,9 +202,10 @@ impl<'a> IronCoreRequest<'a> {
         auth: &Authorization,
     ) -> impl Future<Item = Option<A>, Error = IronOxideErr> {
         //A little lie here, String isn't actually the body type as it's unused
-        self.request::<String, _, _>(
+        self.request::<String, _, String, _>(
             relative_url,
             Method::GET,
+            None,
             None,
             error_code,
             auth.to_header(),
@@ -203,37 +228,25 @@ impl<'a> IronCoreRequest<'a> {
         error_code: RequestErrorCode,
         auth: &Authorization,
     ) -> impl Future<Item = B, Error = IronOxideErr> {
-        self.request(
+        self.request::<A, _, String, _>(
             relative_url,
             Method::DELETE,
             Some(body),
+            None,
             error_code,
             auth.to_header(),
             move |server_resp| IronCoreRequest::deserialize_body(server_resp, error_code),
         )
     }
 
-    pub fn delete_with_no_body<B: DeserializeOwned>(
-        &self,
-        relative_url: &str,
-        error_code: RequestErrorCode,
-        auth: &Authorization,
-    ) -> impl Future<Item = B, Error = IronOxideErr> {
-        self.delete(
-            relative_url,
-            &PhantomData::<u8>, // BS type, maybe there's a better way?
-            error_code,
-            auth,
-        )
-    }
-
     ///Make a request to the url using the specified method. DEFAULT_HEADERS will be used as well as whatever headers are passed
     /// in. The response will be sent to `resp_handler` so the caller can make the received bytes however they want.
-    pub fn request<A, B, F>(
+    pub fn request<A, B, Q, F>(
         &self,
         relative_url: &str,
         method: Method,
         maybe_body: Option<&A>,
+        maybe_query_params: Option<&Q>,
         error_code: RequestErrorCode,
         headers: HeaderMap,
         resp_handler: F,
@@ -241,6 +254,7 @@ impl<'a> IronCoreRequest<'a> {
     where
         A: Serialize,
         B: DeserializeOwned,
+        Q: Serialize + ?Sized,
         F: FnOnce(&Chunk) -> Result<B, IronOxideErr>,
     {
         let client = RClient::new();
@@ -248,6 +262,11 @@ impl<'a> IronCoreRequest<'a> {
             method,
             format!("{}{}", self.base_url, relative_url).as_str(),
         );
+        // add query params, if any
+        builder = maybe_query_params
+            .iter()
+            .fold(builder, |build, q| build.query(q));
+
         //We want to add the body as json if it was specified
         builder = maybe_body
             .iter()
@@ -281,6 +300,20 @@ impl<'a> IronCoreRequest<'a> {
                     resp_handler(&server_resp)
                 }
             })
+    }
+
+    pub fn delete_with_no_body<B: DeserializeOwned>(
+        &self,
+        relative_url: &str,
+        error_code: RequestErrorCode,
+        auth: &Authorization,
+    ) -> impl Future<Item = B, Error = IronOxideErr> {
+        self.delete(
+            relative_url,
+            &PhantomData::<u8>, // BS type, maybe there's a better way?
+            error_code,
+            auth,
+        )
     }
 
     ///Deserialize the body of the response into a Result.

--- a/src/internal/rest.rs
+++ b/src/internal/rest.rs
@@ -273,16 +273,13 @@ impl<'a> IronCoreRequest<'a> {
             .fold(builder, |build, body| build.json(body));
 
         let req = builder.headers(DEFAULT_HEADERS.clone()).headers(headers);
-        dbg!(&req);
         req.send()
             //Parse the body content into bytes
             .and_then(|res| {
-                dbg!(&res);
                 let status_code = res.status();
-                res.into_body().concat2().map(move |body| {
-                    dbg!(&body);
-                    (status_code, body)
-                })
+                res.into_body()
+                    .concat2()
+                    .map(move |body| (status_code, body))
             })
             //Now make the error type into the IronOxideErr and run the resp_handler which was passed to us.
             .then(move |resp| {

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -19,6 +19,11 @@ impl UserId {
     pub fn id(&self) -> &String {
         &self.0
     }
+
+    /// Create a UserId from a string with no validation. Useful for ids coming back from the web service.
+    pub fn unsafe_from_string(id: String) -> UserId {
+        UserId(id)
+    }
 }
 impl TryFrom<String> for UserId {
     type Error = IronOxideErr;
@@ -322,7 +327,7 @@ pub fn user_key_list<'a>(
                     let maybe_pub_key = PublicKey::try_from(user.user_master_public_key.clone());
                     maybe_pub_key.into_iter().for_each(|pub_key| {
                         //We asked the api for valid user ids. We're assuming here that the response has valid user ids.
-                        acc.insert(UserId(user.id.clone()), pub_key);
+                        acc.insert(UserId::unsafe_from_string(user.id.clone()), pub_key);
                     });
                     acc
                 })

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -6,8 +6,11 @@ use chrono::{DateTime, Utc};
 use futures::prelude::*;
 use itertools::{Either, Itertools};
 use recrypt::prelude::*;
-use std::convert::{TryFrom, TryInto};
-use std::{collections::HashMap, result::Result};
+use std::{
+    collections::HashMap,
+    convert::{TryFrom, TryInto},
+    result::Result,
+};
 
 /// private module that handles interaction with ironcore-id
 mod requests;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,8 +51,8 @@ pub mod group;
 /// SDK user operations
 pub mod user;
 
-/// Polcicy types and operations
-//pub mod policy;
+/// Policy types
+pub mod policy;
 
 /// Convenience re-export of essential IronOxide types
 pub mod prelude;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,11 +48,14 @@ pub mod document;
 /// SDK group operations
 pub mod group;
 
-/// Convenience re-export of essential IronOxide types
-pub mod prelude;
-
 /// SDK user operations
 pub mod user;
+
+/// Polcicy types and operations
+//pub mod policy;
+
+/// Convenience re-export of essential IronOxide types
+pub mod prelude;
 
 pub use crate::internal::{
     DeviceContext, DeviceSigningKeyPair, IronOxideErr, KeyPair, PrivateKey, PublicKey,

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -2,15 +2,14 @@
 //! separation of concerns when it comes to labeling data vs defining who to encrypt to.
 //!
 //! Policies are defined using the ironcore admin console: https://admin.ironcorelabs.com/policy
-//! and are stored on the server. This allows a policy to be updated independently any application code.
-//! In the future policies will be able to be programmatically defined using ironoxide.
+//! and are stored on the server. This allows a policy to be updated independently of any application code.
 //!
 //! Data labeling is provided in three dimensions (category, sensitivity, dataSubject).
 //! You only need to use the dimensions that make sense for your use case. The values of the labels
 //! are arbitrary, but the example below may be instructive in selecting label names.
 //!
 //! In addition to defining labels, a list of rules is required to map the labels to a set of users/groups.
-//! Rules are checked in the order they are defined. If a rule matches is can produce any number of users/groups.
+//! Rules are checked in the order they are defined. If a rule matches, it can produce any number of users/groups.
 //! Rules defined after the matching rule will not be processed.
 //!
 //! The `%USER%` and `%LOGGED_IN_USER%` are special tokens that will be replaced when the policy is applied.
@@ -76,8 +75,7 @@
 //! `PolicyGrant::new(None, None, None, None)` will match the last rule in the example and will return
 //! the group [data_recovery]
 //!
-use crate::internal::user_api::UserId;
-use crate::{IronOxideErr, Result};
+use crate::{internal::user_api::UserId, IronOxideErr, Result};
 use regex::Regex;
 use std::convert::TryFrom;
 

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -1,0 +1,263 @@
+//! Policies are a list of rules which map data labels to a list of users/groups. This allows the
+//! separation of concerns when it comes to labeling data vs defining who to encrypt to.
+//!
+//! Policies are defined using the ironcore admin console: https://admin.ironcorelabs.com/policy
+//! and are stored on the server. This allows a policy to be updated independently any application code.
+//! In the future policies will be able to be programmatically defined using ironoxide.
+//!
+//! Data labeling is provided in three dimensions (category, sensitivity, dataSubject).
+//! You only need to use the dimensions that make sense for your use case. The values of the labels
+//! are arbitrary, but the example below may be instructive in selecting label names.
+//!
+//! In addition to defining labels, a list of rules is required to map the labels to a set of users/groups.
+//! Rules are checked in the order they are defined. If a rule matches is can produce any number of users/groups.
+//! Rules defined after the matching rule will not be processed.
+//!
+//! The `%USER%` and `%LOGGED_IN_USER%` are special tokens that will be replaced when the policy is applied.
+//! * `%USER%` - replaced by `substitute_user_id` (see `PolicyGrant`)
+//! * `%LOGGED_IN_USER%` - replaced by the user currently authenticated to make SDK calls.
+//!
+//! A policy could look something like:
+//! ```json
+//! {
+//!  "dataSubjects": [
+//!    "PATIENT",
+//!    "EMPLOYEE"
+//!  ],
+//!  "sensitivities": [
+//!    "RESTRICTED",
+//!    "CLASSIFIED",
+//!    "INTERNAL"
+//!  ],
+//!  "categories": [
+//!    "HEALTH",
+//!    "PII"
+//!  ],
+//!  "rules": [
+//!    {
+//!      "sensitivity": "RESTRICTED",
+//!      "users": [
+//!        "%USER%"
+//!      ],
+//!      "dataSubject": "PATIENT",
+//!      "groups": [
+//!        "group_other_%USER%",
+//!        "group_id_doctors",
+//!        "data_recovery"
+//!      ],
+//!      "category": "HEALTH"
+//!    },
+//!    {
+//!      "sensitivity": "INTERNAL",
+//!      "users": [
+//!        "joe@ironcorelabs",
+//!        "%LOGGED_IN_USER%"
+//!      ],
+//!      "groups": [
+//!        "group_%LOGGED_IN_USER%",
+//!        "data_recovery"
+//!      ],
+//!      "category": "PII"
+//!    },
+//!    {
+//!      "groups": [
+//!        "data_recovery"
+//!      ],
+//!    },
+//!  ]
+//! }
+//! ```
+//! Example:
+//! If the current user of the sdk is "alice@ironcorelabs" and the following PolicyGrant is evaluated,
+//! `PolicyGrant::new("PII".try_from()?, "INTERNAL".try_from()?, None, None)` will match the second-to-last rule
+//! in the example policy, above and will return users: [joe@ironcorelabs, alice@ironcorelabs] and
+//! groups [group_alice@ironcorelabs, data_recovery"]
+//!
+//! `PolicyGrant::new(None, None, None, None)` will match the last rule in the example and will return
+//! the group [data_recovery]
+//!
+use crate::internal::user_api::UserId;
+use crate::{IronOxideErr, Result};
+use regex::Regex;
+use std::convert::TryFrom;
+
+/// Document access granted by a policy. For use with `DocumentOps.document_encrypt`.
+///
+/// The triple (`category`, `sensitivity`, `data_subject`) maps to a single policy rule. Each policy
+/// rule may generate any number of users/groups.
+///
+/// `substitute_user_id` replaces `%USER%` in a matched policy rule.
+#[derive(Debug, PartialEq, Clone)]
+pub struct PolicyGrant {
+    category: Option<Category>,
+    sensitivity: Option<Sensitivity>,
+    data_subject: Option<DataSubject>,
+    substitute_user_id: Option<SubstituteId>,
+}
+
+impl PolicyGrant {
+    pub fn new(
+        category: Option<Category>,
+        sensitivity: Option<Sensitivity>,
+        data_subject: Option<DataSubject>,
+        substitute_user: Option<UserId>,
+    ) -> PolicyGrant {
+        PolicyGrant {
+            category,
+            sensitivity,
+            data_subject,
+            substitute_user_id: substitute_user.map(|u| u.into()),
+        }
+    }
+
+    pub fn category(&self) -> Option<&Category> {
+        self.category.as_ref()
+    }
+
+    pub fn sensitivity(&self) -> Option<&Sensitivity> {
+        self.sensitivity.as_ref()
+    }
+
+    pub fn data_subject(&self) -> Option<&DataSubject> {
+        self.data_subject.as_ref()
+    }
+    pub fn substitute_id(&self) -> Option<&SubstituteId> {
+        self.substitute_user_id.as_ref()
+    }
+}
+
+impl Default for PolicyGrant {
+    fn default() -> Self {
+        PolicyGrant {
+            category: None,
+            sensitivity: None,
+            data_subject: None,
+            substitute_user_id: None,
+        }
+    }
+}
+
+macro_rules! policy_field {
+    ($t: ident, $l: literal) => {
+        #[derive(Debug, PartialEq, Clone)]
+        pub struct $t(pub(crate) String);
+
+        impl TryFrom<&str> for $t {
+            type Error = IronOxideErr;
+
+            fn try_from(value: &str) -> Result<Self> {
+                validate_simple_policy_field_value(value, $l).map(|v| Self(v))
+            }
+        }
+
+        impl $t {
+            pub(crate) const QUERY_PARAM: &'static str = $l;
+        }
+    };
+}
+
+policy_field!(Category, "category");
+policy_field!(DataSubject, "dataSubject");
+policy_field!(Sensitivity, "sensitivity");
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct SubstituteId(pub(crate) UserId);
+
+impl From<UserId> for SubstituteId {
+    fn from(u: UserId) -> Self {
+        SubstituteId(u)
+    }
+}
+impl SubstituteId {
+    pub(crate) const QUERY_PARAM: &'static str = "substituteId";
+}
+
+const NAME_AND_ID_MAX_LEN: usize = 100;
+
+fn validate_simple_policy_field_value(field_id: &str, field_type: &str) -> Result<String> {
+    let simple_policy_field_regex = Regex::new("^[A-Za-z0-9_-]+$").expect("regex is valid");
+    let trimmed_id = field_id.trim();
+    if trimmed_id.is_empty() || trimmed_id.len() > NAME_AND_ID_MAX_LEN {
+        Err(IronOxideErr::ValidationError(
+            field_type.to_string(),
+            format!("'{}' must have length between 1 and 100", trimmed_id),
+        ))
+    } else if !simple_policy_field_regex.is_match(trimmed_id) {
+        Err(IronOxideErr::ValidationError(
+            field_type.to_string(),
+            format!("'{}' contains invalid characters", trimmed_id),
+        ))
+    } else {
+        Ok(trimmed_id.to_string())
+    }
+}
+#[cfg(test)]
+pub(crate) mod test {
+    use super::*;
+    use crate::internal::test::contains;
+
+    #[test]
+    fn validate_simple_policy_id_good() {
+        let name_type = "name_type";
+        let id = "abc-123";
+        let result = validate_simple_policy_field_value(id, name_type);
+        assert_that!(&result, is_variant!(Ok));
+
+        let id = "SIMPLE_2";
+        let result = validate_simple_policy_field_value(id, name_type);
+        assert_that!(&result, is_variant!(Ok));
+
+        let id = "LOTS-O-CHARS_012345678901234567890123456789012345678901234567890123456789012345678901234567890123456";
+        let result = validate_simple_policy_field_value(id, name_type);
+        assert_that!(&result, is_variant!(Ok))
+    }
+
+    #[test]
+    fn validate_simple_policy_id_invalid_chars() {
+        let name_type = "name_type";
+
+        // very limited special chars
+        let invalid = "abc!123";
+        let result = validate_simple_policy_field_value(invalid, name_type);
+        assert_that!(&result, is_variant!(Err));
+        let validation_error = result.unwrap_err();
+        assert_that!(
+            &validation_error,
+            is_variant!(IronOxideErr::ValidationError)
+        );
+
+        //no unicode
+        let invalid = "❤HEART❤";
+        let result = validate_simple_policy_field_value(invalid, name_type);
+        assert_that!(&result, is_variant!(Err));
+        let validation_error = result.unwrap_err();
+        assert_that!(
+            &validation_error,
+            is_variant!(IronOxideErr::ValidationError)
+        );
+
+        // no spaces
+        let invalid = "spaces not allowed";
+        let result = validate_simple_policy_field_value(invalid, name_type);
+        assert_that!(&result, is_variant!(Err));
+        let validation_error = result.unwrap_err();
+        assert_that!(
+            &validation_error,
+            is_variant!(IronOxideErr::ValidationError)
+        );
+    }
+
+    #[test]
+    fn validate_simple_policy_id_invalid_length() {
+        let name_type = "name_type";
+        let invalid = "too many chars 012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";
+        let result = validate_simple_policy_field_value(invalid, name_type);
+        assert_that!(&result, is_variant!(Err));
+        let validation_error = result.unwrap_err();
+        assert_that!(
+            &validation_error,
+            is_variant!(IronOxideErr::ValidationError)
+        );
+        assert_that!(&format!("{}", validation_error), contains("100"));
+    }
+}

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,6 +6,7 @@ pub use crate::{
         group_api::{GroupId, GroupName},
         user_api::{DeviceId, DeviceName, UserId},
     },
+    policy::PolicyGrant,
     user::UserOps,
     DeviceContext, IronOxide, IronOxideErr,
 };

--- a/src/user.rs
+++ b/src/user.rs
@@ -9,8 +9,7 @@ use crate::{
     DeviceContext, IronOxide, Result,
 };
 use recrypt::api::Recrypt;
-use std::collections::HashMap;
-use std::convert::TryInto;
+use std::{collections::HashMap, convert::TryInto};
 use tokio::runtime::current_thread::Runtime;
 
 /// Optional parameters for creating a new device instance.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -46,6 +46,11 @@ pub fn gen_jwt(
 }
 
 pub fn init_sdk() -> IronOxide {
+    let (_, io) = init_sdk_get_user();
+    io
+}
+
+pub fn init_sdk_get_user() -> (UserId, IronOxide) {
     let account_id: UserId = Uuid::new_v4().to_string().try_into().unwrap();
     IronOxide::user_create(
         &gen_jwt(1012, "test-segment", 551, Some(account_id.id())).0,
@@ -84,7 +89,7 @@ pub fn init_sdk() -> IronOxide {
         users_signing_keys_bytes.try_into().unwrap(),
     );
 
-    ironoxide::initialize(&device_init).unwrap()
+    (account_id, ironoxide::initialize(&device_init).unwrap())
 }
 
 pub fn create_second_user() -> UserVerifyResult {

--- a/tests/document_ops.rs
+++ b/tests/document_ops.rs
@@ -89,7 +89,7 @@ fn doc_create_with_policy_grants() -> Result<(), IronOxideErr> {
             &doc,
             &DocumentEncryptOpts::with_policy_grants(
                 None,
-                Some("first name".try_into()?),
+                Some("doc name".try_into()?),
                 PolicyGrant::new(
                     Some("PII".try_into()?),
                     Some("INTERNAL".try_into()?),

--- a/tests/document_ops.rs
+++ b/tests/document_ops.rs
@@ -1,8 +1,11 @@
 mod common;
+use crate::common::init_sdk_get_user;
 use common::{create_second_user, init_sdk};
 use galvanic_assert::matchers::collection::*;
+use galvanic_assert::matchers::*;
 use ironoxide::group::GroupCreateOpts;
 use ironoxide::{document::*, prelude::*, IronOxide};
+use itertools::EitherOrBoth;
 use std::convert::{TryFrom, TryInto};
 
 #[cfg(test)]
@@ -77,12 +80,16 @@ fn doc_create_with_explicit_grants() {
 
 #[test]
 fn doc_create_with_policy_grants() -> Result<(), IronOxideErr> {
-    let mut sdk = init_sdk();
+    let (curr_user, mut sdk) = init_sdk_get_user();
+    let group_id: GroupId = format!("group_{}", curr_user.id()).try_into().unwrap();
+
+    let group_result = sdk.group_create(&GroupCreateOpts::new(group_id.clone().into(), None, true));
+    assert!(group_result.is_ok());
 
     let doc = [0u8; 64];
 
-    let bad_user: UserId = "bad_user".try_into().unwrap();
-    let bad_group: GroupId = "bad_group".try_into().unwrap();
+    //    let bad_user: UserId = "bad_user".try_into().unwrap();
+    //    let bad_group: GroupId = "bad_group".try_into().unwrap();
 
     let doc_result = sdk
         .document_encrypt(
@@ -100,12 +107,21 @@ fn doc_create_with_policy_grants() -> Result<(), IronOxideErr> {
         )
         .unwrap();
 
-    assert_eq!(doc_result.grants().len(), 1);
-    assert_eq!(
-        doc_result.grants()[0],
-        UserOrGroup::User {
-            id: sdk.device().account_id().clone()
-        }
+    assert_eq!(doc_result.grants().len(), 2);
+    assert_that!(
+        &doc_result
+            .grants()
+            .iter()
+            .map(Clone::clone)
+            .collect::<Vec<UserOrGroup>>(),
+        contains_in_any_order(vec![
+            UserOrGroup::User {
+                id: sdk.device().account_id().clone()
+            },
+            UserOrGroup::Group {
+                id: group_id.clone()
+            }
+        ])
     );
     assert_eq!(doc_result.access_errs().len(), 2);
     assert_that!(
@@ -115,13 +131,143 @@ fn doc_create_with_policy_grants() -> Result<(), IronOxideErr> {
             .map(|err| err.user_or_group.clone())
             .collect::<Vec<_>>(),
         contains_in_any_order(vec![
-            UserOrGroup::User { id: bad_user },
-            UserOrGroup::Group { id: bad_group }
+            UserOrGroup::Group {
+                id: "badgroupid_frompolicy".try_into().unwrap()
+            },
+            UserOrGroup::User {
+                id: "baduserid_frompolicy".try_into().unwrap()
+            }
+        ])
+    );
+
+    // now use category, sensitivity, data_subject and substitution_user_id
+    let user2_result = create_second_user();
+    let user2 = user2_result.account_id();
+    let group2_id: GroupId = format!("group_other_{}", user2.id()).try_into().unwrap();
+    let group2_result =
+        sdk.group_create(&GroupCreateOpts::new(group2_id.clone().into(), None, false));
+    assert!(group2_result.is_ok());
+
+    let doc_result2 = sdk
+        .document_encrypt(
+            &doc,
+            &DocumentEncryptOpts::with_policy_grants(
+                None,
+                Some("doc name2".try_into()?),
+                PolicyGrant::new(
+                    Some("HEALTH".try_into()?),
+                    Some("RESTRICTED".try_into()?),
+                    Some("PATIENT".try_into()?),
+                    Some(user2.clone()),
+                )?,
+            ),
+        )
+        .unwrap();
+
+    assert_eq!(doc_result2.grants().len(), 2);
+    assert_that!(
+        &doc_result2
+            .grants()
+            .iter()
+            .map(Clone::clone)
+            .collect::<Vec<UserOrGroup>>(),
+        contains_in_any_order(vec![
+            UserOrGroup::User { id: user2.clone() },
+            UserOrGroup::Group { id: group2_id }
+        ])
+    );
+    assert_eq!(doc_result2.access_errs().len(), 1);
+    assert_that!(
+        &doc_result2
+            .access_errs()
+            .iter()
+            .map(|err| err.user_or_group.clone())
+            .collect::<Vec<_>>(),
+        contains_in_any_order(vec![UserOrGroup::Group {
+            id: "group_id_doctors".try_into().unwrap()
+        },])
+    );
+
+    Ok(())
+}
+#[test]
+fn doc_create_with_explicit_and_policy_grants() -> Result<(), IronOxideErr> {
+    use std::borrow::Borrow;
+
+    let (curr_user, mut sdk) = init_sdk_get_user();
+    let group_id: GroupId = format!("group_{}", curr_user.id()).try_into().unwrap();
+
+    let group_result = sdk.group_create(&GroupCreateOpts::new(group_id.clone().into(), None, true));
+    assert!(group_result.is_ok());
+
+    //create an explicit group as well
+    let group2_result = sdk.group_create(&Default::default());
+    assert!(group2_result.is_ok());
+    let group2 = group2_result?;
+    let ex_group_id = group2.id();
+
+    let doc = [0u8; 64];
+
+    //    let bad_user: UserId = "bad_user".try_into().unwrap();
+    let bad_group: GroupId = "bad_group".try_into().unwrap();
+
+    let doc_result = sdk
+        .document_encrypt(
+            &doc,
+            &DocumentEncryptOpts::new(
+                None,
+                None,
+                EitherOrBoth::Both(
+                    ExplicitGrant::new(true, &vec![ex_group_id.into(), bad_group.borrow().into()]),
+                    PolicyGrant::new(
+                        Some("PII".try_into()?),
+                        Some("INTERNAL".try_into()?),
+                        None,
+                        None,
+                    )?,
+                ),
+            ),
+        )
+        .unwrap();
+
+    assert_eq!(doc_result.grants().len(), 3);
+    assert_that!(
+        &doc_result
+            .grants()
+            .iter()
+            .map(Clone::clone)
+            .collect::<Vec<UserOrGroup>>(),
+        contains_in_any_order(vec![
+            UserOrGroup::User {
+                id: sdk.device().account_id().clone()
+            },
+            UserOrGroup::Group {
+                id: group_id.clone()
+            },
+            UserOrGroup::Group {
+                id: ex_group_id.clone()
+            }
+        ])
+    );
+    assert_eq!(doc_result.access_errs().len(), 3);
+    assert_that!(
+        &doc_result
+            .access_errs()
+            .iter()
+            .map(|err| err.user_or_group.clone())
+            .collect::<Vec<_>>(),
+        contains_in_any_order(vec![
+            UserOrGroup::Group {
+                id: "badgroupid_frompolicy".try_into().unwrap()
+            },
+            UserOrGroup::User {
+                id: "baduserid_frompolicy".try_into().unwrap()
+            },
+            UserOrGroup::Group { id: bad_group } // bad explicit group
         ])
     );
     Ok(())
 }
-
 #[test]
 fn doc_create_without_self_grant() {
     let mut sdk = init_sdk();

--- a/tests/document_ops.rs
+++ b/tests/document_ops.rs
@@ -1,10 +1,8 @@
 mod common;
 use crate::common::init_sdk_get_user;
 use common::{create_second_user, init_sdk};
-use galvanic_assert::matchers::collection::*;
-use galvanic_assert::matchers::*;
-use ironoxide::group::GroupCreateOpts;
-use ironoxide::{document::*, prelude::*, IronOxide};
+use galvanic_assert::matchers::{collection::*, *};
+use ironoxide::{document::*, group::GroupCreateOpts, prelude::*, IronOxide};
 use itertools::EitherOrBoth;
 use std::convert::{TryFrom, TryInto};
 

--- a/tests/document_ops.rs
+++ b/tests/document_ops.rs
@@ -92,10 +92,10 @@ fn doc_create_with_policy_grants() -> Result<(), IronOxideErr> {
                 Some("first name".try_into()?),
                 PolicyGrant::new(
                     Some("PII".try_into()?),
-                    Some("PRIVATE".try_into()?),
-                    Some("EMPLOYEE".try_into()?),
+                    Some("INTERNAL".try_into()?),
                     None,
-                ),
+                    None,
+                )?,
             ),
         )
         .unwrap();
@@ -185,7 +185,7 @@ fn doc_create_must_grant() {
             IronOxideErr::ValidationError(field_name, _) => field_name,
             _ => "failed test".to_string(),
         },
-        "grant_to_author".to_string()
+        "grants".to_string()
     )
 }
 


### PR DESCRIPTION
Encrypt a document via a server side policy!

This feature can be used to take the burden off the caller to assemble the correct set of users and groups that need access to the document. A policy is identified by the triple (Category, Sensitivity, Data Subject) and is stored in the IronCore web service. Given values for the triple, the policy can be evaluated to get the correct set of users and groups from the web service during an encrypt operation.

Policy-based encryption can also be combined with explicit grants.

Read more about policy in policy.rs

## TODO prior to merge
* [x] - additional documentation added to sdk (and this PR)
* [x] - consider moving policy related code to it's own module
* [x] - add a couple more integration tests
