### PR TITLE
Remove type SubstituteId 

### DIFF
--- a/src/internal/document_api/requests.rs
+++ b/src/internal/document_api/requests.rs
@@ -228,7 +228,9 @@ pub mod document_create {
 
 pub mod policy_get {
     use super::*;
-    use crate::policy::{Category, DataSubject, PolicyGrant, Sensitivity, SubstituteId};
+    use crate::policy::{Category, DataSubject, PolicyGrant, Sensitivity};
+
+    pub(crate) const SUBSTITUTE_ID_QUERY_PARAM: &'static str = "substituteId";
 
     #[derive(Deserialize, Debug, Clone)]
     #[serde(rename_all = "camelCase")]
@@ -252,8 +254,8 @@ pub mod policy_get {
                 .data_subject()
                 .map(|d| (DataSubject::QUERY_PARAM.to_string(), d.0.clone())),
             policy_grant
-                .substitute_id()
-                .map(|SubstituteId(UserId(u))| (SubstituteId::QUERY_PARAM.to_string(), u.clone())),
+                .substitute_user()
+                .map(|UserId(u)| (SUBSTITUTE_ID_QUERY_PARAM.to_string(), u.clone())),
         ]
         .to_vec()
         .into_iter()

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -19,7 +19,7 @@ mod requests;
 #[derive(PartialEq, Debug, Serialize, Deserialize, Clone, Eq, Hash)]
 pub struct UserId(pub(crate) String);
 impl UserId {
-    pub fn id(&self) -> &String {
+    pub fn id(&self) -> &str {
         &self.0
     }
 

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -84,7 +84,7 @@ use std::convert::TryFrom;
 /// The triple (`category`, `sensitivity`, `data_subject`) maps to a single policy rule. Each policy
 /// rule may generate any number of users/groups.
 ///
-/// `substitute_user_id replaces `%USER%` in a matched policy rule.
+/// `substitute_user` replaces `%USER%` in a matched policy rule.
 #[derive(Debug, PartialEq, Clone)]
 pub struct PolicyGrant {
     category: Option<Category>,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,7 +6,7 @@ pub fn gen_jwt(
     project_id: usize,
     seg_id: &str,
     service_key_id: usize,
-    account_id: Option<&String>,
+    account_id: Option<&str>,
 ) -> (String, String) {
     use std::env;
 
@@ -83,7 +83,7 @@ pub fn init_sdk_get_user() -> (UserId, IronOxide) {
     let users_signing_keys_bytes = &device.signing_keys().as_bytes()[..];
 
     let device_init = DeviceContext::new(
-        users_account_id.as_str().try_into().unwrap(),
+        users_account_id.try_into().unwrap(),
         users_segment_id,
         users_private_device_key_bytes.try_into().unwrap(),
         users_signing_keys_bytes.try_into().unwrap(),

--- a/tests/document_ops.rs
+++ b/tests/document_ops.rs
@@ -2,7 +2,7 @@ mod common;
 use crate::common::init_sdk_get_user;
 use common::{create_second_user, init_sdk};
 use galvanic_assert::matchers::{collection::*, *};
-use ironoxide::{document::*, group::GroupCreateOpts, prelude::*, IronOxide};
+use ironoxide::{document::*, group::GroupCreateOpts, prelude::*};
 use itertools::EitherOrBoth;
 use std::convert::{TryFrom, TryInto};
 

--- a/tests/document_ops.rs
+++ b/tests/document_ops.rs
@@ -29,6 +29,55 @@ fn doc_create_without_id() {
 
 #[test]
 fn doc_create_with_policy_grants() -> Result<(), IronOxideErr> {
+    // policy assumed for this test
+    /*
+    {
+      "dataSubjects": [
+        "PATIENT"
+      ],
+      "sensitivities": [
+        "RESTRICTED",
+        "INTERNAL"
+      ],
+      "categories": [
+        "HEALTH",
+        "PII"
+      ],
+      "rules": [
+        {
+          "sensitivity": "RESTRICTED",
+          "users": [
+            "%USER%"
+          ],
+          "dataSubject": "PATIENT",
+          "groups": [
+            "group_other_%USER%",
+            "group_id_doctors",
+            "data_recovery_%LOGGED_IN_USER%"
+          ],
+          "category": "HEALTH"
+        },
+        {
+          "sensitivity": "INTERNAL",
+          "users": [
+            "baduserid_frompolicy",
+            "%LOGGED_IN_USER%"
+          ],
+          "groups": [
+            "badgroupid_frompolicy",
+            "data_recovery_%LOGGED_IN_USER%"
+          ],
+          "category": "PII"
+        },
+        {
+          "users": [],
+          "groups": [
+            "data_recovery_%LOGGED_IN_USER%"
+          ]
+        }
+      ]
+    }
+        */
     let (curr_user, mut sdk) = init_sdk_get_user();
 
     //create the data_recovery group used in the policy


### PR DESCRIPTION
...and make string values of PolicyGrant components available to the outside world