### PR TITLE
Add TryFrom to PublicKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,28 @@
 # Changelog
 
+## 0.11.0
+
+- Added `TryFrom<&[u8]>` for `PublicKey`
+- `UserCreateKeyPair` has been renamed to `UserCreateResult`
+- [[#35](https://github.com/IronCoreLabs/ironoxide/pull/35)]
+  - Clarified documentation for several struct parameters.
+- [[#43](https://github.com/IronCoreLabs/ironoxide/pull/43)]
+  - Users can now be created with a `needs_rotation` flag set.
+- [[#47](https://github.com/IronCoreLabs/ironoxide/pull/47)]
+  - `UserVerifyResult` now contains `needs_rotation` for the user.
+
 ## 0.10.1
+
 - [[#32](https://github.com/IronCoreLabs/ironoxide/pull/32)]
   - DocumentAdvancedOps::document_decrypt_unmanaged function added for advanced use cases. This decrypt operation is the inverse of DocumentAdvancedOps::document_encrypt_unmanaged
 
 ## 0.10.0
+
 - [[#27](https://github.com/IronCoreLabs/ironoxide/pull/27)]
   - DocumentAdvancedOps::document_encrypt_unmanaged function added for advanced use cases where the calling application wants to manage both the encrypted data and the associated edeks instead of using the IronCore service for EDEK management.
 
 ## 0.9.0
+
 - [[#23](https://github.com/IronCoreLabs/ironoxide/pull/23)]
   - IronOxide no longer has mutable references in it's API, making it possible to share an IronOxide between threads.
   - The RNG used for for AES now periodically reseeds itself.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironoxide"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironoxide"
-version = "0.11.1"
+version = "0.11.0"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -225,7 +225,7 @@ impl RequestAuth {
     }
 }
 
-/// Accounts device context. Needed to initialize the Sdk with a set of device keys. See `IronOxide.initialize()`
+/// Account's device context. Needed to initialize the Sdk with a set of device keys. See `IronOxide.initialize()`
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeviceContext {
     auth: RequestAuth,

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -84,24 +84,14 @@ impl TryFrom<&str> for DeviceName {
 
 /// Keypair for a newly created user
 #[derive(Debug)]
-pub struct UserCreateKeyPair {
-    // user's private key encrypted with the provided passphrase
-    user_encrypted_master_key: EncryptedMasterKey,
+pub struct UserCreateResult {
     user_public_key: PublicKey,
     // does the private key of this key pair need to be rotated?
     needs_rotation: bool,
 }
 
-impl UserCreateKeyPair {
+impl UserCreateResult {
     /// user's private key encrypted with the provided passphrase
-    pub fn user_encrypted_master_key(&self) -> &EncryptedMasterKey {
-        &self.user_encrypted_master_key
-    }
-
-    pub fn user_encrypted_master_key_bytes(&self) -> [u8; 92] {
-        self.user_encrypted_master_key.bytes()
-    }
-
     pub fn user_public_key(&self) -> &PublicKey {
         &self.user_public_key
     }
@@ -221,7 +211,7 @@ pub fn user_create<CR: rand::CryptoRng + rand::RngCore>(
     passphrase: Password,
     needs_rotation: bool,
     request: IronCoreRequest<'static>,
-) -> impl Future<Item = UserCreateKeyPair, Error = IronOxideErr> {
+) -> impl Future<Item = UserCreateResult, Error = IronOxideErr> {
     recrypt
         .generate_key_pair()
         .map_err(IronOxideErr::from)

--- a/src/internal/user_api/requests.rs
+++ b/src/internal/user_api/requests.rs
@@ -121,7 +121,7 @@ pub mod user_verify {
 }
 
 pub mod user_create {
-    use crate::internal::{user_api::UserCreateKeyPair, TryInto};
+    use crate::internal::{user_api::UserCreateResult, TryInto};
 
     use super::*;
 
@@ -163,12 +163,11 @@ pub mod user_create {
             &Authorization::JwtAuth(jwt),
         )
     }
-    impl TryFrom<UserCreateResponse> for UserCreateKeyPair {
+    impl TryFrom<UserCreateResponse> for UserCreateResult {
         type Error = IronOxideErr;
 
         fn try_from(resp: UserCreateResponse) -> Result<Self, Self::Error> {
-            Ok(UserCreateKeyPair {
-                user_encrypted_master_key: resp.user_private_key.try_into()?,
+            Ok(UserCreateResult {
                 user_public_key: resp.user_master_public_key.try_into()?,
                 needs_rotation: resp.needs_rotation,
             })

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,5 +1,5 @@
 pub use crate::internal::user_api::{
-    UserCreateKeyPair, UserDevice, UserDeviceListResult, UserId, UserVerifyResult,
+    UserCreateResult, UserDevice, UserDeviceListResult, UserId, UserVerifyResult,
 };
 use crate::{
     internal::{
@@ -64,14 +64,14 @@ pub trait UserOps {
     /// - `password` - Password used to encrypt and escrow the user's private master key
     /// - `user_create_opts` - see [`UserCreateOpts`](struct.UserCreateOpts.html)
     /// # Returns
-    /// Newly generated `UserCreateKeyPair` or Err. For most use cases this key pair can
+    /// Newly generated `UserCreateResult` or Err. For most use cases, this public key can
     /// be discarded as IronCore escrows your user's keys. The escrowed keys are unlocked
     /// by the provided password.
     fn user_create(
         jwt: &str,
         password: &str,
         user_create_opts: &UserCreateOpts,
-    ) -> Result<UserCreateKeyPair>;
+    ) -> Result<UserCreateResult>;
 
     /// Get all the devices for the current user
     ///
@@ -134,7 +134,7 @@ impl UserOps for IronOxide {
         jwt: &str,
         password: &str,
         user_create_opts: &UserCreateOpts,
-    ) -> Result<UserCreateKeyPair> {
+    ) -> Result<UserCreateResult> {
         let recrypt = Recrypt::new();
         let mut rt = Runtime::new().unwrap();
         rt.block_on(user_api::user_create(

--- a/src/user.rs
+++ b/src/user.rs
@@ -116,7 +116,7 @@ pub trait UserOps {
     /// - `jwt` - Valid IronCore JWT
     ///
     /// # Returns
-    /// Option of whether the users account record exists in the IronCore system or not. Err if the request couldn't be made.
+    /// Option of whether the user's account record exists in the IronCore system or not. Err if the request couldn't be made.
     fn user_verify(jwt: &str) -> Result<Option<UserVerifyResult>>;
 
     /// Get a list of user public keys given their IDs. Allows discovery of which user IDs have keys in the


### PR DESCRIPTION
Needed some changes for ironoxide-java/ironoxide-scala

- Added `impl TryFrom<&[u8]> for PublicKey`
- Added test for it
- Updated the Changelog for version 0.11.0