### PR TITLE
Change DeviceContext parameters/serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.12.0
 
-- []
+- [[#52](https://github.com/IronCoreLabs/ironoxide/pull/52)]
   - Added `device_id` as a parameter to `DeviceContext::new`, renamed other parameters.
   - Changed Serialization/Deserialization of `DeviceContext`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.12.0
+
+- []
+  - Added `device_id` as a parameter to `DeviceContext::new`, renamed other parameters.
+  - Changed Serialization/Deserialization of `DeviceContext`.
+
 ## 0.11.0
 
 - Added `TryFrom<&[u8]>` for `PublicKey`
@@ -24,20 +30,20 @@
 ## 0.9.0
 
 - [[#23](https://github.com/IronCoreLabs/ironoxide/pull/23)]
-  - IronOxide no longer has mutable references in it's API, making it possible to share an IronOxide between threads.
-  - The RNG used for for AES now periodically reseeds itself.
+  - IronOxide no longer has mutable references in its API, making it possible to share an IronOxide between threads.
+  - The RNG used for AES now periodically reseeds itself.
 
 ## 0.8.0
 
-- add the ability to encrypt via policy
+- Added the ability to encrypt via policy.
 
 ## 0.7.0
 
-- add the ability to encrypt without granting to the author
+- Added the ability to encrypt without granting to the author.
 
 ## 0.6.1
 
-- [[#1](#1)]
+- [[#1](https://github.com/IronCoreLabs/ironoxide/pull/1)]
   - added `UserCreateKeyPair` to public API
   - added `IronOxideErr` to the `prelude`
   - added `From<IronOxideErr> for String` to lib.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironoxide"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/crypto/aes.rs
+++ b/src/crypto/aes.rs
@@ -1,8 +1,7 @@
 use std::{fmt, num::NonZeroU32};
 
 use rand::{self, CryptoRng, RngCore};
-use ring::aead::BoundKey;
-use ring::{aead, digest, error::Unspecified, pbkdf2};
+use ring::{aead, aead::BoundKey, digest, error::Unspecified, pbkdf2};
 
 use crate::internal::{take_lock, IronOxideErr};
 use futures::Future;
@@ -222,8 +221,7 @@ pub fn encrypt<R: CryptoRng + RngCore>(
 }
 
 use futures::future::IntoFuture;
-use std::ops::DerefMut;
-use std::sync::Mutex;
+use std::{ops::DerefMut, sync::Mutex};
 
 /// Like `encrypt`, just wrapped in a Future for convenience
 pub fn encrypt_future<R: CryptoRng + RngCore>(

--- a/src/document/advanced.rs
+++ b/src/document/advanced.rs
@@ -1,9 +1,10 @@
-use crate::document::{partition_user_or_group, DocumentEncryptOpts};
-use crate::internal;
 pub use crate::internal::document_api::{
     DocumentDecryptUnmanagedResult, DocumentEncryptUnmanagedResult,
 };
-use crate::Result;
+use crate::{
+    document::{partition_user_or_group, DocumentEncryptOpts},
+    internal, Result,
+};
 use itertools::EitherOrBoth;
 use tokio::runtime::current_thread::Runtime;
 

--- a/src/document/advanced.rs
+++ b/src/document/advanced.rs
@@ -94,7 +94,7 @@ impl DocumentAdvancedOps for crate::IronOxide {
         rt.block_on(internal::document_api::decrypt_document_unmanaged(
             self.device.auth(),
             &self.recrypt,
-            self.device().private_device_key(),
+            self.device().device_private_key(),
             encrypted_data,
             encrypted_deks,
         ))

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -262,7 +262,7 @@ impl DocumentOps for crate::IronOxide {
         rt.block_on(document_api::document_update_bytes(
             self.device.auth(),
             &self.recrypt,
-            self.device.private_device_key(),
+            self.device.device_private_key(),
             &self.rng,
             id,
             &new_document_data,
@@ -275,7 +275,7 @@ impl DocumentOps for crate::IronOxide {
         rt.block_on(document_api::decrypt_document(
             self.device.auth(),
             &self.recrypt,
-            self.device.private_device_key(),
+            self.device.device_private_key(),
             encrypted_document,
         ))
     }
@@ -308,7 +308,7 @@ impl DocumentOps for crate::IronOxide {
             &self.recrypt,
             id,
             &self.user_master_pub_key,
-            &self.device.private_device_key(),
+            &self.device.device_private_key(),
             &users,
             &groups,
         ))

--- a/src/group.rs
+++ b/src/group.rs
@@ -191,7 +191,7 @@ impl GroupOps for crate::IronOxide {
         rt.block_on(group_api::group_add_members(
             &self.recrypt,
             self.device.auth(),
-            self.device.private_device_key(),
+            self.device.device_private_key(),
             id,
             &grant_list.to_vec(),
         ))
@@ -216,7 +216,7 @@ impl GroupOps for crate::IronOxide {
         rt.block_on(group_api::group_add_admins(
             &self.recrypt,
             self.device.auth(),
-            self.device.private_device_key(),
+            self.device.device_private_key(),
             id,
             &users.to_vec(),
         ))

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -547,7 +547,7 @@ pub fn encrypt_document<
         ))
         .and_then(move |(encrypted_doc, (grants, key_errs))| {
             recrypt_document(
-                &auth.signing_keys,
+                &auth.signing_private_key,
                 recrypt,
                 dek,
                 encrypted_doc,
@@ -661,7 +661,7 @@ where
         .and_then(move |(encryption_result, (grants, key_errs))| {
             Ok({
                 let r = recrypt_document(
-                    &auth.signing_keys,
+                    &auth.signing_private_key,
                     recrypt,
                     dek,
                     encryption_result,
@@ -1700,6 +1700,7 @@ mod tests {
         let aes_value = AesEncryptedValue::try_from(&[42u8; 32][..])?;
         let uid = UserId::unsafe_from_string("userid".into());
         let gid = GroupId::unsafe_from_string("groupid".into());
+        let did = TryFrom::try_from(1).unwrap();
         let user: UserOrGroup = uid.borrow().into();
         let group: UserOrGroup = gid.borrow().into();
         let (priv_key, pubk) = recr.generate_key_pair()?;
@@ -1726,9 +1727,10 @@ mod tests {
             encryption_result.into_edoc(DocumentHeader::new(DocumentId("other_docid".into()), 99));
 
         let auth = RequestAuth {
+            device_id: did,
             account_id: uid,
             segment_id: seg_id,
-            signing_keys: signingkeys,
+            signing_private_key: signingkeys,
             request: IronCoreRequest::default(),
         };
 

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -1075,7 +1075,7 @@ pub fn document_grant_access<'a, CR: rand::CryptoRng + rand::RngCore>(
                 let (grant_errs, grants) = transform::encrypt_to_with_key(
                     recrypt,
                     &dek,
-                    &auth.signing_keys().into(),
+                    &auth.signing_private_key().into(),
                     users_and_groups,
                 );
 

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -1252,8 +1252,7 @@ fn process_policy(
 
 #[cfg(test)]
 mod tests {
-    use crate::internal::test::contains;
-    use crate::internal::user_api::DeviceId;
+    use crate::internal::{test::contains, user_api::DeviceId};
     use base64::decode;
     use galvanic_assert::matchers::{collection::*, *};
 

--- a/src/internal/document_api/requests.rs
+++ b/src/internal/document_api/requests.rs
@@ -1,8 +1,7 @@
 use super::{AssociationType, DocumentId, DocumentName};
-use crate::internal::document_api::EncryptedDek;
 use crate::internal::{
     self,
-    document_api::{UserOrGroup, VisibleGroup, VisibleUser, WithKey},
+    document_api::{EncryptedDek, UserOrGroup, VisibleGroup, VisibleUser, WithKey},
     group_api::GroupId,
     rest::{
         self,
@@ -13,8 +12,7 @@ use crate::internal::{
 };
 use chrono::{DateTime, Utc};
 use futures::Future;
-use std::convert::TryFrom;
-use std::convert::TryInto;
+use std::convert::{TryFrom, TryInto};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Association {
@@ -200,7 +198,6 @@ pub mod edek_transform {
         pub(in crate::internal::document_api) user_or_group: UserOrGroup,
         pub(in crate::internal::document_api) encrypted_symmetric_key: TransformedEncryptedValue,
     }
-
 }
 
 pub mod document_create {
@@ -305,7 +302,6 @@ pub mod policy_get {
             &auth.create_signature(Utc::now()),
         )
     }
-
 }
 
 pub mod document_update {

--- a/src/internal/group_api/mod.rs
+++ b/src/internal/group_api/mod.rs
@@ -297,7 +297,7 @@ pub fn group_create<'a, CR: rand::CryptoRng + rand::RngCore>(
                 let encrypted_group_key = recrypt.encrypt(
                     &plaintext,
                     &user_master_pub_key.into(),
-                    &auth.signing_keys().into(),
+                    &auth.signing_private_key().into(),
                 )?;
 
                 // compute a transform key if we are adding the caller as a group member as well
@@ -307,7 +307,7 @@ pub fn group_create<'a, CR: rand::CryptoRng + rand::RngCore>(
                             .generate_transform_key(
                                 &group_priv_key.into(),
                                 &user_master_pub_key.into(),
-                                &auth.signing_keys().into(),
+                                &auth.signing_private_key().into(),
                             )?
                             .into(),
                     )
@@ -382,7 +382,7 @@ pub fn group_add_members<'a, CR: rand::CryptoRng + rand::RngCore>(
             let (mut transform_fails, transform_success) = generate_transform_for_keys(
                 recrypt,
                 &group_private_key,
-                &auth.signing_keys().into(),
+                &auth.signing_private_key().into(),
                 successes,
             );
             acc_fails.append(&mut transform_fails);
@@ -436,7 +436,7 @@ pub fn group_add_admins<'a, CR: rand::CryptoRng + rand::RngCore>(
             let (recrypt_errors, transform_success) = transform::encrypt_to_with_key(
                 recrypt,
                 &plaintext,
-                &auth.signing_keys().into(),
+                &auth.signing_private_key().into(),
                 successes,
             );
             let mut transform_fails = recrypt_errors

--- a/src/internal/group_api/requests.rs
+++ b/src/internal/group_api/requests.rs
@@ -436,5 +436,4 @@ mod tests {
         let de_result = serde_json::from_str(&result).unwrap();
         assert_eq!(item, de_result)
     }
-
 }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -281,7 +281,7 @@ impl DeviceContext {
         &self.auth.device_id
     }
 
-    pub fn private_device_key(&self) -> &PrivateKey {
+    pub fn device_private_key(&self) -> &PrivateKey {
         &self.device_private_key
     }
 }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -214,9 +214,6 @@ impl RequestAuth {
             &self.signing_private_key,
         )
     }
-    pub fn device_id(&self) -> &DeviceId {
-        &self.device_id
-    }
 
     pub fn account_id(&self) -> &UserId {
         &self.account_id

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -273,7 +273,7 @@ impl DeviceContext {
         self.auth.segment_id
     }
 
-    pub fn signing_keys(&self) -> &DeviceSigningKeyPair {
+    pub fn signing_private_key(&self) -> &DeviceSigningKeyPair {
         &self.auth.signing_private_key
     }
 

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -214,6 +214,9 @@ impl RequestAuth {
             &self.signing_private_key,
         )
     }
+    pub fn device_id(&self) -> &DeviceId {
+        &self.device_id
+    }
 
     pub fn account_id(&self) -> &UserId {
         &self.account_id
@@ -223,7 +226,7 @@ impl RequestAuth {
         self.segment_id
     }
 
-    pub fn signing_keys(&self) -> &DeviceSigningKeyPair {
+    pub fn signing_private_key(&self) -> &DeviceSigningKeyPair {
         &self.signing_private_key
     }
 }

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -287,11 +287,11 @@ pub fn generate_device_key<'a, CR: rand::CryptoRng + rand::RngCore>(
         )
         // call device_add
         .and_then(move |(device_add, account_id, segment_id)| {
-            // discard successful response as it only has the device public key in it, which we already have
             requests::device_add::user_device_add(&jwt, &device_add, &device_name, &request)
                 // on successful response, assemble a DeviceContext for the caller
-                .map(move |_| {
+                .map(move |response| {
                     DeviceContext::new(
+                        response.device_id,
                         account_id,
                         segment_id,
                         device_add.device_keys.private_key,

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -6,11 +6,11 @@ use chrono::{DateTime, Utc};
 use futures::prelude::*;
 use itertools::{Either, Itertools};
 use recrypt::prelude::*;
-use std::sync::Mutex;
 use std::{
     collections::HashMap,
     convert::{TryFrom, TryInto},
     result::Result,
+    sync::Mutex,
 };
 
 /// private module that handles interaction with ironcore-id

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,9 +65,10 @@ pub mod prelude;
 pub use crate::internal::{
     DeviceContext, DeviceSigningKeyPair, IronOxideErr, KeyPair, PrivateKey, PublicKey,
 };
-use rand::rngs::adapter::ReseedingRng;
-use rand::rngs::EntropyRng;
-use rand::FromEntropy;
+use rand::{
+    rngs::{adapter::ReseedingRng, EntropyRng},
+    FromEntropy,
+};
 use rand_chacha::ChaChaCore;
 use recrypt::api::{Ed25519, RandomBytes, Recrypt, Sha256};
 use std::sync::Mutex;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,6 +1,5 @@
 use ironoxide::{prelude::*, user::UserVerifyResult};
-use std::convert::TryInto;
-use std::default::Default;
+use std::{convert::TryInto, default::Default};
 use uuid::Uuid;
 
 pub fn gen_jwt(
@@ -81,7 +80,7 @@ pub fn init_sdk_get_user() -> (UserId, IronOxide) {
 
     let users_account_id = device.account_id().id();
     let users_segment_id = device.segment_id();
-    let users_device_id = *device.device_id().id(); //TODO: Should I be doing this differently? I don't have TryFrom<&u64>
+    let users_device_id = *device.device_id().id();
     let users_device_private_key_bytes = &device.device_private_key().as_bytes()[..];
     let users_signing_keys_bytes = &device.signing_private_key().as_bytes()[..];
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -77,14 +77,16 @@ pub fn init_sdk_get_user() -> (UserId, IronOxide) {
     .unwrap();
 
     //Manually unwrap all of these types and rewrap them just to prove that we can construct the DeviceContext
-    //from it's raw parts as part of the exposed SDK
+    //from its raw parts as part of the exposed SDK
 
     let users_account_id = device.account_id().id();
     let users_segment_id = device.segment_id();
+    let users_device_id = *device.device_id().id(); //TODO: Should I be doing this differently? I don't have TryFrom<&u64>
     let users_private_device_key_bytes = &device.private_device_key().as_bytes()[..];
     let users_signing_keys_bytes = &device.signing_keys().as_bytes()[..];
 
     let device_init = DeviceContext::new(
+        users_device_id.try_into().unwrap(),
         users_account_id.try_into().unwrap(),
         users_segment_id,
         users_private_device_key_bytes.try_into().unwrap(),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -82,14 +82,14 @@ pub fn init_sdk_get_user() -> (UserId, IronOxide) {
     let users_account_id = device.account_id().id();
     let users_segment_id = device.segment_id();
     let users_device_id = *device.device_id().id(); //TODO: Should I be doing this differently? I don't have TryFrom<&u64>
-    let users_private_device_key_bytes = &device.private_device_key().as_bytes()[..];
+    let users_device_private_key_bytes = &device.device_private_key().as_bytes()[..];
     let users_signing_keys_bytes = &device.signing_keys().as_bytes()[..];
 
     let device_init = DeviceContext::new(
         users_device_id.try_into().unwrap(),
         users_account_id.try_into().unwrap(),
         users_segment_id,
-        users_private_device_key_bytes.try_into().unwrap(),
+        users_device_private_key_bytes.try_into().unwrap(),
         users_signing_keys_bytes.try_into().unwrap(),
     );
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -83,7 +83,7 @@ pub fn init_sdk_get_user() -> (UserId, IronOxide) {
     let users_segment_id = device.segment_id();
     let users_device_id = *device.device_id().id(); //TODO: Should I be doing this differently? I don't have TryFrom<&u64>
     let users_device_private_key_bytes = &device.device_private_key().as_bytes()[..];
-    let users_signing_keys_bytes = &device.signing_keys().as_bytes()[..];
+    let users_signing_keys_bytes = &device.signing_private_key().as_bytes()[..];
 
     let device_init = DeviceContext::new(
         users_device_id.try_into().unwrap(),

--- a/tests/document_ops.rs
+++ b/tests/document_ops.rs
@@ -2,11 +2,17 @@ mod common;
 use crate::common::init_sdk_get_user;
 use common::{create_second_user, init_sdk};
 use galvanic_assert::matchers::{collection::*, *};
-use ironoxide::group::GroupCreateOpts;
-use ironoxide::{document::advanced::*, document::*, prelude::*, IronOxide};
+use ironoxide::{
+    document::{advanced::*, *},
+    group::GroupCreateOpts,
+    prelude::*,
+    IronOxide,
+};
 use itertools::EitherOrBoth;
-use std::convert::{TryFrom, TryInto};
-use std::sync::Arc;
+use std::{
+    convert::{TryFrom, TryInto},
+    sync::Arc,
+};
 
 #[cfg(test)]
 #[macro_use]

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -1,9 +1,10 @@
 mod common;
 use common::gen_jwt;
-use ironoxide::user::UserCreateOpts;
-use ironoxide::{prelude::*, user::DeviceCreateOpts};
-use std::convert::TryInto;
-use std::default::Default;
+use ironoxide::{
+    prelude::*,
+    user::{DeviceCreateOpts, UserCreateOpts},
+};
+use std::{convert::TryInto, default::Default};
 use uuid::Uuid;
 
 #[macro_use]


### PR DESCRIPTION
- Changed DeviceContext::new to take a device_id, renamed some parameters
- Flattened serialization of RequestAuth for DeviceContext
- Added test that serialization of DeviceContext matches new format

TODO: 
- [x] Add the pull request link to CHANGELOG.md
- [x] Address TODO in tests/common/mod.rs:83