### PR TITLE
Add needs_rotation to group responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.12.1
+
+- [[#56](https://github.com/IronCoreLabs/ironoxide/pull/56)]
+  - Added `needs_rotation` as an `Option<bool>` to `GroupMetaResult`, `GroupGetResult`, `GroupBasicApiResponse`, and `GroupGetApiResponse`.
+
 ## 0.12.0
 
 - [[#52](https://github.com/IronCoreLabs/ironoxide/pull/52)]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironoxide"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/internal/group_api/mod.rs
+++ b/src/internal/group_api/mod.rs
@@ -177,7 +177,8 @@ impl GroupGetResult {
     pub fn member_list(&self) -> Option<&Vec<UserId>> {
         self.member_list.as_ref()
     }
-    /// None if the calling user is not a group admin
+    /// `Some(boolean)` indicating if the group needs rotation if the calling user is a group admin.
+    /// `None` if the calling user is not a group admin.
     pub fn needs_rotation(&self) -> Option<bool> {
         self.needs_rotation
     }

--- a/src/internal/group_api/mod.rs
+++ b/src/internal/group_api/mod.rs
@@ -124,6 +124,8 @@ impl GroupMetaResult {
     pub fn group_master_public_key(&self) -> &PublicKey {
         &self.group_master_public_key
     }
+    /// `Some(boolean)` indicating if the group needs rotation if the calling user is a group admin.
+    /// `None` if the calling user is not a group admin.
     pub fn needs_rotation(&self) -> Option<bool> {
         self.needs_rotation
     }

--- a/src/internal/group_api/mod.rs
+++ b/src/internal/group_api/mod.rs
@@ -97,6 +97,7 @@ pub struct GroupMetaResult {
     is_member: bool,
     created: DateTime<Utc>,
     updated: DateTime<Utc>,
+    needs_rotation: Option<bool>,
 }
 impl GroupMetaResult {
     /// A single document grant/revoke failure for a user or group.
@@ -123,6 +124,9 @@ impl GroupMetaResult {
     pub fn group_master_public_key(&self) -> &PublicKey {
         &self.group_master_public_key
     }
+    pub fn needs_rotation(&self) -> Option<bool> {
+        self.needs_rotation
+    }
 }
 
 /// Group information.
@@ -137,6 +141,7 @@ pub struct GroupGetResult {
     member_list: Option<Vec<UserId>>,
     created: DateTime<Utc>,
     updated: DateTime<Utc>,
+    needs_rotation: Option<bool>,
     pub(crate) encrypted_private_key: Option<TransformedEncryptedValue>,
 }
 impl GroupGetResult {
@@ -171,6 +176,10 @@ impl GroupGetResult {
     /// List of group members. Members of a group can decrypt values encrypted to the group.
     pub fn member_list(&self) -> Option<&Vec<UserId>> {
         self.member_list.as_ref()
+    }
+    /// None if the calling user is not a group admin
+    pub fn needs_rotation(&self) -> Option<bool> {
+        self.needs_rotation
     }
 }
 

--- a/src/internal/group_api/requests.rs
+++ b/src/internal/group_api/requests.rs
@@ -30,6 +30,7 @@ pub struct GroupBasicApiResponse {
     pub(crate) updated: DateTime<Utc>,
     pub(crate) created: DateTime<Utc>,
     pub(crate) group_master_public_key: PublicKey,
+    pub(crate) needs_rotation: Option<bool>,
 }
 impl TryFrom<GroupBasicApiResponse> for GroupMetaResult {
     type Error = IronOxideErr;
@@ -44,6 +45,7 @@ impl TryFrom<GroupBasicApiResponse> for GroupMetaResult {
             is_member: resp.permissions.contains(&Permission::Member),
             created: resp.created,
             updated: resp.updated,
+            needs_rotation: resp.needs_rotation,
         })
     }
 }
@@ -61,6 +63,7 @@ pub struct GroupGetApiResponse {
     pub(crate) member_ids: Option<Vec<String>>,
     pub(crate) group_master_public_key: PublicKey,
     pub(crate) encrypted_private_key: Option<TransformedEncryptedValue>,
+    pub(crate) needs_rotation: Option<bool>,
 }
 impl TryFrom<GroupGetApiResponse> for GroupGetResult {
     type Error = IronOxideErr;
@@ -82,6 +85,7 @@ impl TryFrom<GroupGetApiResponse> for GroupGetResult {
                 .map(|members| members.into_iter().map(UserId).collect()),
             created: resp.created,
             updated: resp.updated,
+            needs_rotation: resp.needs_rotation,
         })
     }
 }
@@ -423,6 +427,7 @@ mod tests {
             permissions,
             created,
             updated,
+            needs_rotation: Some(true),
         };
         let result = serde_json::to_string(&item).unwrap();
         assert!(

--- a/tests/group_ops.rs
+++ b/tests/group_ops.rs
@@ -30,24 +30,25 @@ fn group_create_also_member() {
 }
 
 #[test]
-fn group_get_metadata() {
+fn group_get_metadata() -> Result<(), IronOxideErr> {
     let admin_sdk = init_sdk();
     let member_sdk = init_sdk();
     let nonmember_sdk = init_sdk();
 
     let member_id = member_sdk.device().account_id().clone();
     let group = admin_sdk.group_create(&Default::default());
-    let group_id = &group.unwrap().id().clone();
+    let group_id = &group?.id().clone();
 
-    let _ = admin_sdk.group_add_members(&group_id, &[member_id]);
+    admin_sdk.group_add_members(&group_id, &[member_id])?;
 
-    let admin_group_get = admin_sdk.group_get_metadata(group_id).unwrap();
-    let member_group_get = member_sdk.group_get_metadata(group_id).unwrap();
-    let nonmember_group_get = nonmember_sdk.group_get_metadata(group_id).unwrap();
+    let admin_group_get = admin_sdk.group_get_metadata(group_id)?;
+    let member_group_get = member_sdk.group_get_metadata(group_id)?;
+    let nonmember_group_get = nonmember_sdk.group_get_metadata(group_id)?;
 
     assert_eq!(admin_group_get.needs_rotation(), Some(false));
     assert_eq!(member_group_get.needs_rotation(), None);
     assert_eq!(nonmember_group_get.needs_rotation(), None);
+    Ok(())
 }
 
 #[test]

--- a/tests/group_ops.rs
+++ b/tests/group_ops.rs
@@ -18,7 +18,7 @@ fn group_create_no_member() {
         false,
     ));
 
-    assert!(group_result.is_ok())
+    assert_eq!(group_result.unwrap().needs_rotation(), Some(false))
 }
 
 #[test]
@@ -26,8 +26,28 @@ fn group_create_also_member() {
     let sdk = init_sdk();
 
     let group_result = sdk.group_create(&Default::default());
+    assert_eq!(group_result.unwrap().needs_rotation(), Some(false))
+}
 
-    assert!(group_result.is_ok())
+#[test]
+fn group_get_metadata() {
+    let admin_sdk = init_sdk();
+    let member_sdk = init_sdk();
+    let nonmember_sdk = init_sdk();
+
+    let member_id = member_sdk.device().account_id().clone();
+    let group = admin_sdk.group_create(&Default::default());
+    let group_id = &group.unwrap().id().clone();
+
+    let _ = admin_sdk.group_add_members(&group_id, &[member_id]);
+
+    let admin_group_get = admin_sdk.group_get_metadata(group_id).unwrap();
+    let member_group_get = member_sdk.group_get_metadata(group_id).unwrap();
+    let nonmember_group_get = nonmember_sdk.group_get_metadata(group_id).unwrap();
+
+    assert_eq!(admin_group_get.needs_rotation(), Some(false));
+    assert_eq!(member_group_get.needs_rotation(), None);
+    assert_eq!(nonmember_group_get.needs_rotation(), None);
 }
 
 #[test]


### PR DESCRIPTION
- Added needs_rotation as an `Option<bool>` to:
    - `GroupMetaResult`
    - `GroupGetResult`
    - `GroupBasicApiResponse`
    - `GroupGetApiResponse`
- `GroupListResult` is simply a `Vec<GroupMetaResult>`, so it will get these changes.
- Added a test for `group_get_metadata()` that tests a call by an admin, member, and non-member.

`needs_rotation` will be a `None` for a non-admin, and a `Some` for an admin.
