### PR TITLE
44 user private key rotate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rand = "~0.6"
 rand_chacha = "~0.1"
 regex = "~1.1"
 ring = { version= "~0.16", features = ["std"] }
-recrypt = "~0.8.1"
+recrypt = "~0.8.2"
 reqwest = "~0.9"
 tokio = "~0.1"
 hex = "~0.3"

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -362,7 +362,7 @@ impl DocumentEncryptResult {
     }
 }
 /// Result of decrypting a document. Includes minimal metadata as well as the decrypted bytes.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct DocumentDecryptResult {
     id: DocumentId,
     name: Option<DocumentName>,

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -362,7 +362,7 @@ impl DocumentEncryptResult {
     }
 }
 /// Result of decrypting a document. Includes minimal metadata as well as the decrypted bytes.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct DocumentDecryptResult {
     id: DocumentId,
     name: Option<DocumentName>,

--- a/src/internal/document_api/requests.rs
+++ b/src/internal/document_api/requests.rs
@@ -204,8 +204,10 @@ pub mod edek_transform {
 
 pub mod document_create {
     use super::*;
-    use crate::internal::auth_v2::AuthV2Builder;
-    use crate::internal::document_api::{DocumentName, EncryptedDek};
+    use crate::internal::{
+        auth_v2::AuthV2Builder,
+        document_api::{DocumentName, EncryptedDek},
+    };
     use std::convert::TryInto;
 
     #[derive(Serialize, Debug, Clone, Deserialize, PartialEq)]
@@ -265,8 +267,10 @@ pub mod document_create {
 
 pub mod policy_get {
     use super::*;
-    use crate::internal::rest::{url_encode, PercentEncodedString};
-    use crate::policy::{Category, DataSubject, PolicyGrant, Sensitivity};
+    use crate::{
+        internal::rest::{url_encode, PercentEncodedString},
+        policy::{Category, DataSubject, PolicyGrant, Sensitivity},
+    };
 
     pub(crate) const SUBSTITUTE_ID_QUERY_PARAM: &'static str = "substituteId";
 
@@ -334,8 +338,10 @@ pub mod document_update {
 
 pub mod document_access {
     use super::*;
-    use crate::internal::auth_v2::AuthV2Builder;
-    use crate::internal::document_api::{requests::document_access::resp::*, UserOrGroup, WithKey};
+    use crate::internal::{
+        auth_v2::AuthV2Builder,
+        document_api::{requests::document_access::resp::*, UserOrGroup, WithKey},
+    };
     use std::convert::TryInto;
 
     pub mod resp {

--- a/src/internal/group_api/requests.rs
+++ b/src/internal/group_api/requests.rs
@@ -166,8 +166,7 @@ pub mod group_list {
 
 pub mod group_create {
     use super::*;
-    use crate::internal::auth_v2::AuthV2Builder;
-    use crate::internal::{self, rest::json::EncryptedOnceValue};
+    use crate::internal::{self, auth_v2::AuthV2Builder, rest::json::EncryptedOnceValue};
     use futures::prelude::*;
     use std::convert::TryFrom;
 

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -44,6 +44,7 @@ pub enum RequestErrorCode {
     UserDeviceDelete,
     UserDeviceList,
     UserKeyList,
+    UserKeyUpdate,
     GroupCreate,
     GroupDelete,
     GroupList,

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -496,6 +496,7 @@ impl PrivateKey {
                 "Augmenting key cannot be zero".into(),
             ))
         } else {
+            //TODO is this the right direction?
             let augmented_key = self.0.clone() - augmenting_key.clone().into();
             // TODO might be nice if Revealed could hold a reference
             if Revealed(augmented_key.clone()) == Revealed(zero) {

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -496,7 +496,7 @@ impl PrivateKey {
                 "Augmenting key cannot be zero".into(),
             ))
         } else {
-            //TODO is this the right direction?
+            // this subtractions needs to be the additive inverse of what the service is doing
             let augmented_key = self.0.clone() - augmenting_key.clone().into();
             // TODO might be nice if Revealed could hold a reference
             if Revealed(augmented_key.clone()) == Revealed(zero) {

--- a/src/internal/rest.rs
+++ b/src/internal/rest.rs
@@ -793,7 +793,7 @@ impl<'a> IronCoreRequest<'a> {
                 Some(status_code),
             )
         } else {
-            //If the status code is an error we can try and rip off the ServerErrors which ironcore-id
+            //If the status code is an error we can try and rip off the ServerErrors which the webservice
             //returns, otherwise process it the way the user wants.
             IronCoreRequest::deserialize_body::<Vec<ServerError>>(&body, error_code)
                 .map(|error_response| IronOxideErr::RequestServerErrors {

--- a/src/internal/rest.rs
+++ b/src/internal/rest.rs
@@ -1,8 +1,7 @@
 //! Helpers for talking to the ironcore service.
 
 use chrono::{DateTime, Utc};
-use futures::IntoFuture;
-use futures::{stream::Stream, Future};
+use futures::{stream::Stream, Future, IntoFuture};
 use reqwest::{
     header::HeaderMap,
     r#async::{Chunk, Client as RClient, Request as ARequest},
@@ -11,19 +10,21 @@ use reqwest::{
 use serde::{de::DeserializeOwned, Serialize};
 use std::marker::PhantomData;
 
-use crate::internal::auth_v2::AuthV2Builder;
 use crate::internal::{
-    user_api::UserId, DeviceSigningKeyPair, IronOxideErr, Jwt, RequestErrorCode, OUR_REQUEST,
+    auth_v2::AuthV2Builder, user_api::UserId, DeviceSigningKeyPair, IronOxideErr, Jwt,
+    RequestErrorCode, OUR_REQUEST,
 };
 use futures::future::Either;
 use percent_encoding::SIMPLE_ENCODE_SET;
-use reqwest::header::{HeaderValue, CONTENT_TYPE};
-use reqwest::r#async::RequestBuilder;
-use serde::export::fmt::{Display, Error};
-use serde::export::Formatter;
-use std::borrow::BorrowMut;
-use std::ops::Deref;
-use std::str::from_utf8;
+use reqwest::{
+    header::{HeaderValue, CONTENT_TYPE},
+    r#async::RequestBuilder,
+};
+use serde::export::{
+    fmt::{Display, Error},
+    Formatter,
+};
+use std::{borrow::BorrowMut, ops::Deref, str::from_utf8};
 
 lazy_static! {
     static ref DEFAULT_HEADERS: HeaderMap = {

--- a/src/internal/rest.rs
+++ b/src/internal/rest.rs
@@ -667,6 +667,7 @@ impl<'a> IronCoreRequest<'a> {
         B: DeserializeOwned + 'a,
         F: FnOnce(&Chunk) -> Result<B, IronOxideErr> + 'a,
     {
+        dbg!(&req);
         let client = RClient::new();
         client
             .execute(req)
@@ -679,6 +680,7 @@ impl<'a> IronCoreRequest<'a> {
             })
             //Now make the error type into the IronOxideErr and run the resp_handler which was passed to us.
             .then(move |resp| {
+                dbg!(&resp);
                 //Map the generic error from reqwest to our error type.
                 let (status, server_resp) = resp.map_err(|err| {
                     IronCoreRequest::create_request_err(err.to_string(), error_code, err.status())

--- a/src/internal/rest.rs
+++ b/src/internal/rest.rs
@@ -23,6 +23,7 @@ use serde::export::fmt::{Display, Error};
 use serde::export::Formatter;
 use std::borrow::BorrowMut;
 use std::ops::Deref;
+use std::str::from_utf8;
 
 lazy_static! {
     static ref DEFAULT_HEADERS: HeaderMap = {
@@ -605,6 +606,11 @@ impl<'a> IronCoreRequest<'a> {
                     vec![]
                 };
 
+                println!(
+                    "REQUEST: {:?} \n-->with BODY {:?}",
+                    &req,
+                    from_utf8(&body_bytes)
+                );
                 (req, body_bytes)
             })
         };
@@ -667,7 +673,6 @@ impl<'a> IronCoreRequest<'a> {
         B: DeserializeOwned + 'a,
         F: FnOnce(&Chunk) -> Result<B, IronOxideErr> + 'a,
     {
-        dbg!(&req);
         let client = RClient::new();
         client
             .execute(req)

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -86,13 +86,13 @@ impl TryFrom<&str> for DeviceName {
 
 /// Keypair for a newly created user
 #[derive(Debug)]
-pub struct UserCreateResult {
+pub struct UserResult {
     user_public_key: PublicKey,
     // does the private key of this key pair need to be rotated?
     needs_rotation: bool,
 }
 
-impl UserCreateResult {
+impl UserResult {
     /// user's private key encrypted with the provided passphrase
     pub fn user_public_key(&self) -> &PublicKey {
         &self.user_public_key
@@ -213,7 +213,7 @@ pub fn user_create<CR: rand::CryptoRng + rand::RngCore>(
     passphrase: Password,
     needs_rotation: bool,
     request: IronCoreRequest<'static>,
-) -> impl Future<Item = UserCreateResult, Error = IronOxideErr> {
+) -> impl Future<Item = UserResult, Error = IronOxideErr> {
     recrypt
         .generate_key_pair()
         .map_err(IronOxideErr::from)
@@ -249,13 +249,13 @@ impl EncryptedPrivateKey {
 
 #[derive(Debug, Clone)]
 pub struct UserUpdatePrivateKeyResult {
-    user_key_id: usize,
+    user_key_id: u64,
     user_master_private_key: EncryptedPrivateKey,
     needs_rotation: bool,
 }
 
 impl UserUpdatePrivateKeyResult {
-    pub fn user_key_id(&self) -> usize {
+    pub fn user_key_id(&self) -> u64 {
         self.user_key_id
     }
     pub fn user_master_private_key(&self) -> &EncryptedPrivateKey {
@@ -269,7 +269,6 @@ impl UserUpdatePrivateKeyResult {
 pub fn user_get_current(
     auth: &RequestAuth,
 ) -> impl Future<Item = UserVerifyResult, Error = IronOxideErr> + '_ {
-    //TODO type
     requests::user_get::get_curr_user(auth).and_then(|result| {
         Ok(UserVerifyResult {
             needs_rotation: result.needs_rotation,

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -238,9 +238,32 @@ pub fn user_create<CR: rand::CryptoRng + rand::RngCore>(
         .and_then(|resp| resp.try_into())
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EncryptedPrivateKey(Vec<u8>);
+
+impl EncryptedPrivateKey {
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct UserUpdatePrivateKeyResult {
     user_key_id: usize,
+    user_master_private_key: EncryptedPrivateKey,
+    needs_rotation: bool,
+}
+
+impl UserUpdatePrivateKeyResult {
+    pub fn user_key_id(&self) -> usize {
+        self.user_key_id
+    }
+    pub fn user_master_private_key(&self) -> &EncryptedPrivateKey {
+        &self.user_master_private_key
+    }
+    pub fn needs_rotation(&self) -> bool {
+        self.needs_rotation
+    }
 }
 
 pub fn user_soft_rotate_key<'apicall, CR: rand::CryptoRng + rand::RngCore>(
@@ -270,7 +293,7 @@ pub fn user_soft_rotate_key<'apicall, CR: rand::CryptoRng + rand::RngCore>(
                     UserId(curr_user.id),
                     curr_user.current_key_id,
                     new_encrypted_priv_key,
-                    aug_factor.as_bytes().to_vec(),
+                    aug_factor,
                 )
             })
         })
@@ -281,17 +304,11 @@ pub fn user_soft_rotate_key<'apicall, CR: rand::CryptoRng + rand::RngCore>(
                     user_id,
                     curr_key_id,
                     new_encrypted_priv_key.into(),
-                    aug_factor,
+                    aug_factor.into(),
                 )
                 .map(|resp| resp.into())
             },
         )
-
-    // generate the augmentation factor
-    //        let aug_factor = generate_augmentation_factor();
-    // compute new private key for user
-    // encrypt new private key with passphrase
-    // invoke REST endpoint
 }
 
 /// Generate a device key for the user specified in the JWT.

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -352,6 +352,10 @@ pub fn generate_device_key<'a, CR: rand::CryptoRng + rand::RngCore>(
                   }| {
                 Ok((
                     {
+                        println!(
+                            "User Verify - EncryptedPrivateKey - {:?}",
+                            &user_private_key
+                        );
                         let user_public_key: RecryptPublicKey =
                             PublicKey::try_from(user_master_public_key)?.into();
                         let user_private_key =

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -244,10 +244,8 @@ pub fn user_soft_rotate_key<CR: rand::CryptoRng + rand::RngCore>(
     passphrase: Password,
     auth: &RequestAuth,
 ) -> Result<UserPrivateKeyRotationResult, IronOxideErr> {
-    get
-
     // generate the augmentation factor
-    let aug_factor = generate_augmentation_factor()
+    //    let aug_factor = generate_augmentation_factor();
     // compute new private key for user
     // encrypt new private key with passphrase
     // invoke REST endpoint

--- a/src/internal/user_api/requests.rs
+++ b/src/internal/user_api/requests.rs
@@ -137,7 +137,7 @@ pub mod user_get {
     #[derive(Deserialize, PartialEq, Debug)]
     #[serde(rename_all = "camelCase")]
     pub struct CurrentUserResponse {
-        pub(in crate::internal) current_key_id: usize,
+        pub(in crate::internal) current_key_id: u64,
         pub(in crate::internal) id: String,
         pub(in crate::internal) status: usize,
         pub(in crate::internal) segment_id: usize,
@@ -172,7 +172,7 @@ pub mod user_update_private_key {
     #[derive(Deserialize, PartialEq, Debug)]
     #[serde(rename_all = "camelCase")]
     pub struct UserUpdatePrivateKeyResponse {
-        current_key_id: usize,
+        current_key_id: u64,
         user_private_key: EncryptedPrivateKey,
         needs_rotation: bool,
     }
@@ -192,7 +192,7 @@ pub mod user_update_private_key {
     pub fn update_private_key<'a>(
         auth: &'a RequestAuth,
         user_id: UserId,
-        user_key_id: usize, //TODO type
+        user_key_id: u64,
         new_encrypted_private_key: EncryptedPrivateKey,
         augmenting_key: AugmentationFactor,
     ) -> impl Future<Item = UserUpdatePrivateKeyResponse, Error = IronOxideErr> + 'a {
@@ -213,7 +213,7 @@ pub mod user_update_private_key {
 }
 
 pub mod user_create {
-    use crate::internal::{user_api::UserCreateResult, TryInto};
+    use crate::internal::{user_api::UserResult, TryInto};
 
     use super::*;
 
@@ -255,11 +255,11 @@ pub mod user_create {
             &Authorization::JwtAuth(jwt),
         )
     }
-    impl TryFrom<UserCreateResponse> for UserCreateResult {
+    impl TryFrom<UserCreateResponse> for UserResult {
         type Error = IronOxideErr;
 
         fn try_from(resp: UserCreateResponse) -> Result<Self, Self::Error> {
-            Ok(UserCreateResult {
+            Ok(UserResult {
                 user_public_key: resp.user_master_public_key.try_into()?,
                 needs_rotation: resp.needs_rotation,
             })

--- a/src/internal/user_api/requests.rs
+++ b/src/internal/user_api/requests.rs
@@ -46,7 +46,7 @@ impl TryFrom<EncryptedPrivateKey> for EncryptedMasterKey {
 }
 
 pub mod user_verify {
-    use crate::internal::user_api::UserVerifyResult;
+    use crate::internal::user_api::UserResult;
     use std::convert::TryInto;
 
     use super::*;
@@ -73,11 +73,11 @@ pub mod user_verify {
         )
     }
 
-    impl TryFrom<UserVerifyResponse> for UserVerifyResult {
+    impl TryFrom<UserVerifyResponse> for UserResult {
         type Error = IronOxideErr;
 
         fn try_from(body: UserVerifyResponse) -> Result<Self, Self::Error> {
-            Ok(UserVerifyResult {
+            Ok(UserResult {
                 account_id: body.id.try_into()?,
                 segment_id: body.segment_id,
                 user_public_key: body.user_master_public_key.try_into()?,
@@ -115,11 +115,11 @@ pub mod user_verify {
                 user_master_public_key: pub_key,
                 needs_rotation: t_needs_rotation,
             };
-            let result: UserVerifyResult = resp.try_into().unwrap();
+            let result: UserResult = resp.try_into().unwrap();
 
             assert_that!(
                 &result,
-                has_structure!(UserVerifyResult {
+                has_structure!(UserResult {
                     account_id: eq(t_account_id.clone()),
                     segment_id: eq(t_segment_id),
                     user_public_key: eq(t_user_public_key.clone()),
@@ -158,6 +158,7 @@ pub mod user_get {
     }
 }
 
+/// PUT /users/{userId}/keys/{userKeyId}
 pub mod user_update_private_key {
     use super::*;
     use crate::internal::user_api::UserUpdatePrivateKeyResult;
@@ -213,7 +214,7 @@ pub mod user_update_private_key {
 }
 
 pub mod user_create {
-    use crate::internal::{user_api::UserResult, TryInto};
+    use crate::internal::{user_api::UserCreateResult, TryInto};
 
     use super::*;
 
@@ -255,11 +256,11 @@ pub mod user_create {
             &Authorization::JwtAuth(jwt),
         )
     }
-    impl TryFrom<UserCreateResponse> for UserResult {
+    impl TryFrom<UserCreateResponse> for UserCreateResult {
         type Error = IronOxideErr;
 
         fn try_from(resp: UserCreateResponse) -> Result<Self, Self::Error> {
-            Ok(UserResult {
+            Ok(UserCreateResult {
                 user_public_key: resp.user_master_public_key.try_into()?,
                 needs_rotation: resp.needs_rotation,
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ impl PrivateKeyRotationCheckResult {
     //        unimplemented!()
     //    }
 
-    //    pub fn rotate_all(ironoxide: &IronOxide) -> (UserId, Vec<GroupId>) //TODO?
+    //    pub fn rotate_all(ironoxide: &IronOxide) -> (UserId, Vec<GroupId>) //TODO consider when group private key rotation is added
 }
 
 /// Initialize the IronOxide SDK with a device. Verifies that the provided user/segment exists and the provided device
@@ -193,8 +193,6 @@ pub fn initialize_check_rotation(device_context: &DeviceContext) -> Result<InitA
             }
         }),
     )
-    //    initialize(&device_context).map(|io| InitAndRotationCheck::NoRotationNeeded(io))
-    //TODO passthrough
 }
 
 impl IronOxide {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,8 @@ pub fn initialize(device_context: &DeviceContext) -> Result<IronOxide> {
 /// marked for private key rotation, or if any of the groups that the user is an admin of is marked
 /// for private key rotation.
 pub fn initialize_check_rotation(device_context: &DeviceContext) -> Result<InitAndRotationCheck> {
-    Ok(unimplemented!())
+    initialize(&device_context).map(|io| InitAndRotationCheck::NoRotationNeeded(io))
+    //TODO passthrough
 }
 
 impl IronOxide {

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,6 +1,6 @@
 use crate::internal::user_api::UserUpdatePrivateKeyResult;
 pub use crate::internal::user_api::{
-    UserCreateResult, UserDevice, UserDeviceListResult, UserId, UserVerifyResult,
+    UserDevice, UserDeviceListResult, UserId, UserResult, UserVerifyResult,
 };
 use crate::{
     internal::{
@@ -72,7 +72,7 @@ pub trait UserOps {
         jwt: &str,
         password: &str,
         user_create_opts: &UserCreateOpts,
-    ) -> Result<UserCreateResult>;
+    ) -> Result<UserResult>;
 
     /// Get all the devices for the current user
     ///
@@ -137,7 +137,7 @@ impl UserOps for IronOxide {
         jwt: &str,
         password: &str,
         user_create_opts: &UserCreateOpts,
-    ) -> Result<UserCreateResult> {
+    ) -> Result<UserResult> {
         let recrypt = Recrypt::new();
         let mut rt = Runtime::new().unwrap();
         rt.block_on(user_api::user_create(

--- a/src/user.rs
+++ b/src/user.rs
@@ -2,7 +2,6 @@ use crate::internal::user_api::UserPrivateKeyRotationResult;
 pub use crate::internal::user_api::{
     UserCreateResult, UserDevice, UserDeviceListResult, UserId, UserVerifyResult,
 };
-use crate::internal::Password;
 use crate::{
     internal::{
         user_api::{self, DeviceId, DeviceName},
@@ -190,16 +189,12 @@ impl UserOps for IronOxide {
     }
 
     fn user_rotate_private_key(&self, password: &str) -> Result<UserPrivateKeyRotationResult> {
-        use futures::future::IntoFuture;
         let mut rt = Runtime::new().unwrap();
-        rt.block_on(
-            user_api::user_soft_rotate_key(
-                &self.recrypt,
-                password.try_into()?,
-                self.device().auth(),
-            )
-            .into_future(),
-        )
+        rt.block_on(user_api::user_soft_rotate_key(
+            &self.recrypt,
+            password.try_into()?,
+            self.device().auth(),
+        ))
     }
 }
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,6 +1,8 @@
+use crate::internal::user_api::UserPrivateKeyRotationResult;
 pub use crate::internal::user_api::{
     UserCreateKeyPair, UserDevice, UserDeviceListResult, UserId, UserVerifyResult,
 };
+use crate::internal::Password;
 use crate::{
     internal::{
         user_api::{self, DeviceId, DeviceName},
@@ -128,6 +130,8 @@ pub trait UserOps {
     /// # Returns
     /// Map from user ID to users public key. Only users who have public keys will be returned in the map.
     fn user_get_public_key(&self, users: &[UserId]) -> Result<HashMap<UserId, PublicKey>>;
+
+    fn user_rotate_private_key(&self, password: &str) -> Result<UserPrivateKeyRotationResult>;
 }
 impl UserOps for IronOxide {
     fn user_create(
@@ -183,6 +187,19 @@ impl UserOps for IronOxide {
     fn user_get_public_key(&self, users: &[UserId]) -> Result<HashMap<UserId, PublicKey>> {
         let mut rt = Runtime::new().unwrap();
         rt.block_on(user_api::user_key_list(self.device.auth(), &users.to_vec()))
+    }
+
+    fn user_rotate_private_key(&self, password: &str) -> Result<UserPrivateKeyRotationResult> {
+        use futures::future::IntoFuture;
+        let mut rt = Runtime::new().unwrap();
+        rt.block_on(
+            user_api::user_soft_rotate_key(
+                &self.recrypt,
+                password.try_into()?,
+                self.device().auth(),
+            )
+            .into_future(),
+        )
     }
 }
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,4 +1,4 @@
-use crate::internal::user_api::UserPrivateKeyRotationResult;
+use crate::internal::user_api::UserUpdatePrivateKeyResult;
 pub use crate::internal::user_api::{
     UserCreateResult, UserDevice, UserDeviceListResult, UserId, UserVerifyResult,
 };
@@ -130,7 +130,7 @@ pub trait UserOps {
     /// Map from user ID to users public key. Only users who have public keys will be returned in the map.
     fn user_get_public_key(&self, users: &[UserId]) -> Result<HashMap<UserId, PublicKey>>;
 
-    fn user_rotate_private_key(&self, password: &str) -> Result<UserPrivateKeyRotationResult>;
+    fn user_rotate_private_key(&self, password: &str) -> Result<UserUpdatePrivateKeyResult>;
 }
 impl UserOps for IronOxide {
     fn user_create(
@@ -188,7 +188,7 @@ impl UserOps for IronOxide {
         rt.block_on(user_api::user_key_list(self.device.auth(), &users.to_vec()))
     }
 
-    fn user_rotate_private_key(&self, password: &str) -> Result<UserPrivateKeyRotationResult> {
+    fn user_rotate_private_key(&self, password: &str) -> Result<UserUpdatePrivateKeyResult> {
         let mut rt = Runtime::new().unwrap();
         rt.block_on(user_api::user_soft_rotate_key(
             &self.recrypt,

--- a/src/user.rs
+++ b/src/user.rs
@@ -190,7 +190,7 @@ impl UserOps for IronOxide {
 
     fn user_rotate_private_key(&self, password: &str) -> Result<UserUpdatePrivateKeyResult> {
         let mut rt = Runtime::new().unwrap();
-        rt.block_on(user_api::user_soft_rotate_key(
+        rt.block_on(user_api::user_rotate_private_key(
             &self.recrypt,
             password.try_into()?,
             self.device().auth(),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,7 @@
-use ironoxide::{prelude::*, user::UserVerifyResult};
+use ironoxide::{
+    prelude::*, user::UserVerifyResult, InitAndRotationCheck, IronOxide,
+    PrivateKeyRotationCheckResult,
+};
 use std::convert::TryInto;
 use std::default::Default;
 use uuid::Uuid;
@@ -52,6 +55,10 @@ pub fn init_sdk() -> IronOxide {
 }
 
 pub fn init_sdk_get_user() -> (UserId, IronOxide) {
+    let (u, init_check) = init_sdk_get_init_result();
+    (u, init_check.unwrap())
+}
+pub fn init_sdk_get_init_result() -> (UserId, InitAndRotationCheck) {
     let account_id: UserId = Uuid::new_v4().to_string().try_into().unwrap();
     IronOxide::user_create(
         &gen_jwt(1012, "test-segment", 551, Some(account_id.id())).0,
@@ -90,8 +97,10 @@ pub fn init_sdk_get_user() -> (UserId, IronOxide) {
         users_private_device_key_bytes.try_into().unwrap(),
         users_signing_keys_bytes.try_into().unwrap(),
     );
-
-    (account_id, ironoxide::initialize(&device_init).unwrap())
+    (
+        account_id,
+        ironoxide::initialize_check_rotation(&device_init).unwrap(),
+    )
 }
 
 pub fn create_second_user() -> UserVerifyResult {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -69,12 +69,10 @@ pub fn init_sdk_get_init_result(user_needs_rotation: bool) -> (UserId, InitAndRo
     )
     .unwrap();
 
-    let result =
+    let verify_resp =
         IronOxide::user_verify(&gen_jwt(1012, "test-segment", 551, Some(account_id.id())).0)
+            .unwrap()
             .unwrap();
-    assert_eq!(true, result.is_some());
-    let verify_resp = result.unwrap();
-
     assert_eq!(&account_id, verify_resp.account_id());
     assert_eq!(2012, verify_resp.segment_id());
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,7 +1,7 @@
-use ironoxide::user::UserCreateOpts;
 use ironoxide::{
-    prelude::*, user::UserVerifyResult, InitAndRotationCheck, IronOxide,
-    PrivateKeyRotationCheckResult,
+    prelude::*,
+    user::{UserCreateOpts, UserResult},
+    InitAndRotationCheck, IronOxide,
 };
 use std::{convert::TryInto, default::Default};
 use uuid::Uuid;
@@ -105,7 +105,7 @@ pub fn init_sdk_get_init_result(user_needs_rotation: bool) -> (UserId, InitAndRo
     )
 }
 
-pub fn create_second_user() -> UserVerifyResult {
+pub fn create_second_user() -> UserResult {
     let (jwt, _) = gen_jwt(1012, "test-segment", 551, Some(&create_id_all_classes("")));
     let create_result = IronOxide::user_create(&jwt, USER_PASSWORD, &Default::default());
     assert!(create_result.is_ok());

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -118,7 +118,8 @@ pub fn create_id_all_classes(prefix: &str) -> String {
     format!(
         "{}{}{}",
         prefix,
-        "abcABC012_.$#|@/:;=+'-",
+        "",
+        //        "abcABC012_.$#|@/:;=+'-", //TODO
         Uuid::new_v4().to_string()
     )
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,4 @@
+use ironoxide::user::UserCreateOpts;
 use ironoxide::{
     prelude::*, user::UserVerifyResult, InitAndRotationCheck, IronOxide,
     PrivateKeyRotationCheckResult,
@@ -56,15 +57,15 @@ pub fn init_sdk() -> IronOxide {
 }
 
 pub fn init_sdk_get_user() -> (UserId, IronOxide) {
-    let (u, init_check) = init_sdk_get_init_result();
+    let (u, init_check) = init_sdk_get_init_result(false);
     (u, init_check.unwrap())
 }
-pub fn init_sdk_get_init_result() -> (UserId, InitAndRotationCheck) {
+pub fn init_sdk_get_init_result(user_needs_rotation: bool) -> (UserId, InitAndRotationCheck) {
     let account_id: UserId = create_id_all_classes("").try_into().unwrap();
     IronOxide::user_create(
         &gen_jwt(1012, "test-segment", 551, Some(account_id.id())).0,
         USER_PASSWORD,
-        &Default::default(),
+        &UserCreateOpts::new(user_needs_rotation),
     )
     .unwrap();
 
@@ -120,8 +121,7 @@ pub fn create_id_all_classes(prefix: &str) -> String {
     format!(
         "{}{}{}",
         prefix,
-        "",
-        //        "abcABC012_.$#|@/:;=+'-", //TODO
+        "abcABC012_.$#|@/:;=+'-",
         Uuid::new_v4().to_string()
     )
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -5,6 +5,8 @@ use ironoxide::{
 use std::{convert::TryInto, default::Default};
 use uuid::Uuid;
 
+pub const USER_PASSWORD: &str = "foo";
+
 pub fn gen_jwt(
     project_id: usize,
     seg_id: &str,
@@ -61,7 +63,7 @@ pub fn init_sdk_get_init_result() -> (UserId, InitAndRotationCheck) {
     let account_id: UserId = create_id_all_classes("").try_into().unwrap();
     IronOxide::user_create(
         &gen_jwt(1012, "test-segment", 551, Some(account_id.id())).0,
-        "foo",
+        USER_PASSWORD,
         &Default::default(),
     )
     .unwrap();
@@ -77,7 +79,7 @@ pub fn init_sdk_get_init_result() -> (UserId, InitAndRotationCheck) {
 
     let device = IronOxide::generate_new_device(
         &gen_jwt(1012, "test-segment", 551, Some(account_id.id())).0,
-        "foo",
+        USER_PASSWORD,
         &Default::default(),
     )
     .unwrap();
@@ -106,7 +108,7 @@ pub fn init_sdk_get_init_result() -> (UserId, InitAndRotationCheck) {
 
 pub fn create_second_user() -> UserVerifyResult {
     let (jwt, _) = gen_jwt(1012, "test-segment", 551, Some(&create_id_all_classes("")));
-    let create_result = IronOxide::user_create(&jwt, "foo", &Default::default());
+    let create_result = IronOxide::user_create(&jwt, USER_PASSWORD, &Default::default());
     assert!(create_result.is_ok());
 
     let verify_result = IronOxide::user_verify(&jwt);

--- a/tests/document_ops.rs
+++ b/tests/document_ops.rs
@@ -6,7 +6,7 @@ use ironoxide::{
     document::{advanced::*, *},
     group::GroupCreateOpts,
     prelude::*,
-    IronOxide,
+    InitAndRotationCheck, IronOxide,
 };
 use itertools::EitherOrBoth;
 use std::{
@@ -584,6 +584,29 @@ fn doc_decrypt_unmanaged_no_access() {
         .unwrap_err();
 
     assert_that!(&decrypt_err, is_variant!(IronOxideErr::RequestServerErrors));
+}
+
+#[test]
+fn decrypt_with_rotated_user_private_key() -> Result<(), IronOxideErr> {
+    let (_, init_result) = common::init_sdk_get_init_result(true);
+
+    let sdk = init_result.unwrap();
+
+    println!("after init");
+    let encrypted_doc = sdk.document_encrypt(
+        &[42u8, 43u8],
+        &DocumentEncryptOpts::with_explicit_grants(None, None, true, vec![]),
+    )?;
+    dbg!(&encrypted_doc);
+    let decrypt_result1 = sdk.document_decrypt(encrypted_doc.encrypted_data())?;
+    dbg!(&decrypt_result1);
+    let rotation_result = sdk.user_rotate_private_key(common::USER_PASSWORD)?;
+    //    rotation_result.
+    let decrypt_result2 = sdk.document_decrypt(encrypted_doc.encrypted_data())?;
+    dbg!(&decrypt_result2);
+
+    assert_eq!(&decrypt_result1, &decrypt_result2);
+    Ok(())
 }
 
 #[test]

--- a/tests/document_ops.rs
+++ b/tests/document_ops.rs
@@ -6,7 +6,7 @@ use ironoxide::{
     document::{advanced::*, *},
     group::GroupCreateOpts,
     prelude::*,
-    InitAndRotationCheck, IronOxide,
+    IronOxide,
 };
 use itertools::EitherOrBoth;
 use std::{
@@ -592,18 +592,13 @@ fn decrypt_with_rotated_user_private_key() -> Result<(), IronOxideErr> {
 
     let sdk = init_result.unwrap();
 
-    println!("after init");
     let encrypted_doc = sdk.document_encrypt(
         &[42u8, 43u8],
         &DocumentEncryptOpts::with_explicit_grants(None, None, true, vec![]),
     )?;
-    dbg!(&encrypted_doc);
     let decrypt_result1 = sdk.document_decrypt(encrypted_doc.encrypted_data())?;
-    dbg!(&decrypt_result1);
-    let rotation_result = sdk.user_rotate_private_key(common::USER_PASSWORD)?;
-    //    rotation_result.
+    sdk.user_rotate_private_key(common::USER_PASSWORD)?;
     let decrypt_result2 = sdk.document_decrypt(encrypted_doc.encrypted_data())?;
-    dbg!(&decrypt_result2);
 
     assert_eq!(&decrypt_result1, &decrypt_result2);
     Ok(())

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -100,6 +100,8 @@ fn user_private_key_rotation() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
+// TODO test device add using rotated private key
+
 #[test]
 fn sdk_init_with_private_key_rotation() -> Result<(), IronOxideErr> {
     use ironoxide::InitAndRotationCheck;

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -84,8 +84,17 @@ fn user_create_good_with_devices() {
 }
 
 #[test]
+fn user_get_current() -> Result<(), IronOxideErr> {
+    let io = common::init_sdk();
+
+    dbg!(io.user_rotate_private_key("asdf"));
+
+    Ok(())
+}
+
+#[test]
 fn user_private_key_rotation() -> Result<(), IronOxideErr> {
-    let (_, init_result) = common::init_sdk_get_init_result();
+    //    let (_, init_result) = common::init_sdk_get_init_result();
 
     //    // case 1: don't handle RotationNeeded
     //    let sdk: IronOxide = init_result.unwrap();

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -87,7 +87,7 @@ fn user_create_good_with_devices() {
 fn user_get_current() -> Result<(), IronOxideErr> {
     let io = common::init_sdk();
 
-    dbg!(io.user_rotate_private_key("asdf"));
+    dbg!(io.user_rotate_private_key("foo"));
 
     Ok(())
 }

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -84,17 +84,25 @@ fn user_create_good_with_devices() {
 }
 
 #[test]
-fn user_get_current() -> Result<(), IronOxideErr> {
+fn user_private_key_rotation() -> Result<(), IronOxideErr> {
     let io = common::init_sdk();
 
-    dbg!(io.user_rotate_private_key("foo"));
+    let result1 = io.user_rotate_private_key(common::USER_PASSWORD)?;
+    assert_eq!(result1.needs_rotation(), false);
+
+    let result2 = io.user_rotate_private_key(common::USER_PASSWORD)?;
+    assert_eq!(&result1.user_key_id(), &result2.user_key_id());
+    assert_ne!(
+        &result1.user_master_private_key(),
+        &result2.user_master_private_key()
+    );
 
     Ok(())
 }
 
 #[test]
-fn user_private_key_rotation() -> Result<(), IronOxideErr> {
-    //    let (_, init_result) = common::init_sdk_get_init_result();
+fn sdk_init_with_private_key_rotation() -> Result<(), IronOxideErr> {
+    let (_, init_result) = common::init_sdk_get_init_result();
 
     //    // case 1: don't handle RotationNeeded
     //    let sdk: IronOxide = init_result.unwrap();
@@ -124,7 +132,7 @@ fn user_create_with_needs_rotation() -> Result<(), IronOxideErr> {
     let account_id: UserId = Uuid::new_v4().to_string().try_into().unwrap();
     let result = IronOxide::user_create(
         &gen_jwt(1012, "test-segment", 551, Some(account_id.id())).0,
-        "foo",
+        common::USER_PASSWORD,
         &UserCreateOpts::new(true),
     );
     assert!(result?.needs_rotation());

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -67,6 +67,33 @@ fn user_create_good_with_devices() {
 }
 
 #[test]
+fn user_private_key_rotation() -> Result<(), IronOxideErr>{_
+    let (_, init_result) = common::init_sdk_get_init_result();
+
+    //    // case 1: don't handle RotationNeeded
+    //    let sdk: IronOxide = init_result.unwrap();
+    //
+    //    let (_, init_result) = common::init_sdk_get_init_result();
+    //    // case 2: handle with a standard pattern match
+    //    let sdk: IronOxide = match init_result {
+    //        IronOxideInitResult::Ok(io) => io,
+    //        IronOxideInitResult::RotationNeeded(with_rotation) => {
+    //            let rotation_result = with_rotation.soft_rotate_curr_user("users_master_password")?;
+    //            with_rotation.into_ironoxide()
+    //        }
+    //    };
+    //
+    //    let (_, init_result) = common::init_sdk_get_init_result();
+    //    // case 3: use a convenience function for handling rotation
+    //    let sdk: IronOxide = init_result.unwrap_or_handle_rotation(|with_rotation| {
+    //        let rotation_result = with_rotation.soft_rotate_curr_user("users_master_password")?;
+    //        Ok(with_rotation.into_ironoxide())
+    //    })?;
+
+    Ok(())
+}
+
+#[test]
 fn user_create_with_needs_rotation() -> Result<(), IronOxideErr> {
     let account_id: UserId = Uuid::new_v4().to_string().try_into().unwrap();
     let result = IronOxide::user_create(

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -101,8 +101,6 @@ fn user_private_key_rotation() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
-// TODO test device add using rotated private key
-
 #[test]
 fn sdk_init_with_private_key_rotation() -> Result<(), IronOxideErr> {
     use ironoxide::InitAndRotationCheck;
@@ -117,7 +115,6 @@ fn sdk_init_with_private_key_rotation() -> Result<(), IronOxideErr> {
     let sdk: IronOxide = match init_result {
         InitAndRotationCheck::NoRotationNeeded(io) => panic!("user should need rotation"),
         InitAndRotationCheck::RotationNeeded(io, rotation_check) => {
-            // TODO should we have a rotate_all() function?
             assert_eq!(rotation_check.user_rotation_needed(), Some(user_id));
             let rotation_result = io.user_rotate_private_key(common::USER_PASSWORD)?;
             assert_eq!(rotation_result.needs_rotation(), false);

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -84,7 +84,7 @@ fn user_create_good_with_devices() {
 }
 
 #[test]
-fn user_private_key_rotation() -> Result<(), IronOxideErr>{_
+fn user_private_key_rotation() -> Result<(), IronOxideErr> {
     let (_, init_result) = common::init_sdk_get_init_result();
 
     //    // case 1: don't handle RotationNeeded

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -1,7 +1,7 @@
 mod common;
 use common::{create_id_all_classes, gen_jwt};
-use ironoxide::document::DocumentEncryptOpts;
 use ironoxide::{
+    document::DocumentEncryptOpts,
     prelude::*,
     user::{DeviceCreateOpts, UserCreateOpts},
 };
@@ -105,15 +105,9 @@ fn user_private_key_rotation() -> Result<(), IronOxideErr> {
 fn sdk_init_with_private_key_rotation() -> Result<(), IronOxideErr> {
     use ironoxide::InitAndRotationCheck;
 
-    let (_, init_result) = common::init_sdk_get_init_result(true);
-
-    //    // case 1: don't handle RotationNeeded
-    let sdk: IronOxide = init_result.unwrap();
-
     let (user_id, init_result) = common::init_sdk_get_init_result(true);
-    // case 2: handle with a standard pattern match
-    let sdk: IronOxide = match init_result {
-        InitAndRotationCheck::NoRotationNeeded(io) => panic!("user should need rotation"),
+    let _: IronOxide = match init_result {
+        InitAndRotationCheck::NoRotationNeeded(_ironoxide) => panic!("user should need rotation"),
         InitAndRotationCheck::RotationNeeded(io, rotation_check) => {
             assert_eq!(rotation_check.user_rotation_needed(), Some(user_id));
             let rotation_result = io.user_rotate_private_key(common::USER_PASSWORD)?;


### PR DESCRIPTION
See #44 

## TODO
* resolve issue with generating devices after user private key rotation

## Changelog
* Adds method `UserOps::user_rotate_private_key`
* Adds a new initialization option: `ironoxide::initialize_check_rotation` to enable users to know if any of their private keys need rotation.