### PR TITLE
[#55] Moves generated code from transform.proto into the rust OUT_DIR

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,13 @@
 extern crate protobuf_codegen_pure;
+use std::env;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::Path;
 
 fn main() {
+    let out_dir = env::var("OUT_DIR").expect("OUT_DIR should exist");
     protobuf_codegen_pure::run(protobuf_codegen_pure::Args {
-        out_dir: "src/proto",
+        out_dir: out_dir.as_str(),
         input: &["proto/transform.proto"],
         includes: &["proto"],
         customize: protobuf_codegen_pure::Customize {
@@ -12,4 +17,23 @@ fn main() {
         },
     })
     .expect("protoc");
+
+    // Work around from https://github.com/googlecartographer/point_cloud_viewer/blob/440d875f12e32dff6107233f24b5a02cf28776dc/point_viewer_proto_rust/build.rs#L33
+    // https://github.com/stepancheg/rust-protobuf/issues/117
+    // https://github.com/rust-lang/rust/issues/18810.
+    // We open the file, add 'mod proto { mod transform { } }' around the contents and write it back. This allows us
+    // to include! the file in lib.rs and have a proper proto module.
+    let proto_path = Path::new(&out_dir).join("transform.rs");
+    let mut contents = String::new();
+
+    File::open(&proto_path)
+        .unwrap()
+        .read_to_string(&mut contents)
+        .unwrap();
+    let new_contents = format!("pub mod proto {{pub mod transform {{ \n{}\n}}}}", contents);
+
+    File::create(&proto_path)
+        .unwrap()
+        .write_all(new_contents.as_bytes())
+        .unwrap();
 }

--- a/build.rs
+++ b/build.rs
@@ -6,9 +6,10 @@ use std::path::Path;
 
 fn main() {
     let out_dir = env::var("OUT_DIR").expect("OUT_DIR should exist");
+    let name = "transform";
     protobuf_codegen_pure::run(protobuf_codegen_pure::Args {
         out_dir: out_dir.as_str(),
-        input: &["proto/transform.proto"],
+        input: &[format!("proto/{}.proto", name).as_str()],
         includes: &["proto"],
         customize: protobuf_codegen_pure::Customize {
             carllerche_bytes_for_bytes: Some(true),
@@ -23,14 +24,14 @@ fn main() {
     // https://github.com/rust-lang/rust/issues/18810.
     // We open the file, add 'mod proto { mod transform { } }' around the contents and write it back. This allows us
     // to include! the file in lib.rs and have a proper proto module.
-    let proto_path = Path::new(&out_dir).join("transform.rs");
+    let proto_path = Path::new(&out_dir).join(format!("{}.rs", name));
     let mut contents = String::new();
 
     File::open(&proto_path)
         .unwrap()
         .read_to_string(&mut contents)
         .unwrap();
-    let new_contents = format!("pub mod proto {{pub mod transform {{ \n{}\n}}}}", contents);
+    let new_contents = format!("pub mod proto {{pub mod {} {{ \n{}\n}}}}", name, contents);
 
     File::create(&proto_path)
         .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,9 @@ extern crate percent_encoding;
 mod crypto;
 mod internal;
 
-mod proto;
+// include generated proto code as a proto module
+// pub mod proto
+include!(concat!(env!("OUT_DIR"), "/transform.rs"));
 
 /// SDK document operations
 pub mod document;

--- a/src/proto/mod.rs
+++ b/src/proto/mod.rs
@@ -1,1 +1,0 @@
-pub mod transform;


### PR DESCRIPTION
Should address #55 

rust-protobuf's documentation shows putting generated code directly into the project's `src/` directory. cargo has always discouraged writing to `src/`as part of the build process, but now docs.rs's sandboxing is actually enforcing this.

Various codegen examples show using the `include!` macro to bring generated code in from the cargo `OUT_DIR`, but the code that rust-protobuf generates isn't really compatible with that approach as it has some top-level `allow` macros that are "out of place" when brought in with the `include` trick.

The solution I've implemented is to wrap the generated code in a module. It's not pretty but I came across a couple of places doing the [same](https://hclarke.ca/generated-code-in-rust.html) [thing](https://github.com/stepancheg/rust-protobuf/issues/117).

If rust-protobuf doesn't get better official support, we may want to consider moving to different proto code generator, but this works for now.