### PR TITLE
[#64] Adds needs_rotation to group creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.14.0 (Unreleased)
+- [[#64](https://github.com/IronCoreLabs/ironoxide/pull/64)]
+  - Adds need_rotation to `GroupCreateOpts`, allowing a group to be created with its private key marked for rotation
+
 ## 0.13.0
 
 - [[#59](https://github.com/IronCoreLabs/ironoxide/pull/59)]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironoxide"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/group.rs
+++ b/src/group.rs
@@ -11,13 +11,16 @@ use tokio::runtime::current_thread::Runtime;
 #[derive(Clone)]
 /// Options for group creation.
 pub struct GroupCreateOpts {
-    /// unique id of a group within a segment. If none, the server will assign an id.
+    // unique id of a group within a segment. If none, the server will assign an id.
     id: Option<GroupId>,
-    /// human readable name of the group. Does not need to be unique.
+    // human readable name of the group. Does not need to be unique.
     name: Option<GroupName>,
-    /// true (default) - creating user will be added to the group's membership (in addition to being the group's admin);
-    /// false - creating user will not be added to the group's membership
+    // true (default) - creating user will be added to the group's membership (in addition to being the group's admin);
+    // false - creating user will not be added to the group's membership
     add_as_member: bool,
+    // true - group's private key will be marked for rotation
+    // false (default) - group's private key will not be marked for rotation
+    needs_rotation: bool,
 }
 
 impl GroupCreateOpts {
@@ -27,17 +30,22 @@ impl GroupCreateOpts {
     /// - `id` - Unique id of a group within a segment. If none, the server will assign an id.
     /// - `name` - Human readable name of the group. Does not need to be unique. Will **not** be encrypted.
     /// - `add_as_member`
-    ///   - `true` - The creating user should be added as a member (in addition to being a group admin)
-    ///   - `false` - The creating user will not be a member of the group, but will still be an admin.
+    ///     - `true` - The creating user should be added as a member (in addition to being a group admin)
+    ///     - `false` - The creating user will not be a member of the group, but will still be an admin.
+    /// - `needs_rotation`
+    ///     - true - group's private key will be marked for rotation
+    ///     - false (default) - group's private key will not be marked for rotation
     pub fn new(
         id: Option<GroupId>,
         name: Option<GroupName>,
         add_as_member: bool,
+        needs_rotation: bool,
     ) -> GroupCreateOpts {
         GroupCreateOpts {
             id,
             name,
             add_as_member,
+            needs_rotation,
         }
     }
 }
@@ -45,7 +53,7 @@ impl GroupCreateOpts {
 impl Default for GroupCreateOpts {
     fn default() -> Self {
         // membership is the default!
-        GroupCreateOpts::new(None, None, true)
+        GroupCreateOpts::new(None, None, true, false)
     }
 }
 
@@ -155,6 +163,7 @@ impl GroupOps for crate::IronOxide {
             id: maybe_id,
             name: maybe_name,
             add_as_member,
+            needs_rotation,
         } = opts.clone();
 
         rt.block_on(group_api::group_create(
@@ -164,6 +173,7 @@ impl GroupOps for crate::IronOxide {
             maybe_id,
             maybe_name,
             add_as_member,
+            needs_rotation,
         ))
     }
 

--- a/src/internal/group_api/mod.rs
+++ b/src/internal/group_api/mod.rs
@@ -294,6 +294,7 @@ pub(crate) fn get_group_keys<'a>(
 /// `name` - name for the group. Does not need to be unique.
 /// `add_as_member` - if true the user represented by the current DeviceContext will also be added to the group's membership.
 ///     If false, the user will not be an member (but will still be an admin)
+/// `needs_rotation` - true if the group private key should be rotated by an admin, else false
 pub fn group_create<'a, CR: rand::CryptoRng + rand::RngCore>(
     recrypt: &'a Recrypt<Sha256, Ed25519, RandomBytes<CR>>,
     auth: &'a RequestAuth,
@@ -301,6 +302,7 @@ pub fn group_create<'a, CR: rand::CryptoRng + rand::RngCore>(
     group_id: Option<GroupId>,
     name: Option<GroupName>,
     add_as_member: bool,
+    needs_rotation: bool,
 ) -> impl Future<Item = GroupMetaResult, Error = IronOxideErr> + 'a {
     transform::gen_group_keys(recrypt)
         .and_then(move |(plaintext, group_priv_key, group_pub_key)| {
@@ -340,6 +342,7 @@ pub fn group_create<'a, CR: rand::CryptoRng + rand::RngCore>(
                 group_pub_key,
                 auth.account_id(),
                 transform_key,
+                needs_rotation,
             )
         })
         .and_then(|resp| resp.try_into())

--- a/src/internal/group_api/requests.rs
+++ b/src/internal/group_api/requests.rs
@@ -177,11 +177,12 @@ pub mod group_create {
     #[derive(Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct GroupCreateReq {
-        pub id: Option<GroupId>,
-        pub name: Option<GroupName>,
-        pub admins: Vec<GroupAdmin>,
-        pub group_public_key: PublicKey,
-        pub members: Option<Vec<GroupMember>>,
+        pub(in crate::internal) id: Option<GroupId>,
+        pub(in crate::internal) name: Option<GroupName>,
+        pub(in crate::internal) admins: Vec<GroupAdmin>,
+        pub(in crate::internal) group_public_key: PublicKey,
+        pub(in crate::internal) members: Option<Vec<GroupMember>>,
+        pub(in crate::internal) needs_rotation: bool,
     }
 
     pub fn group_create<'a>(
@@ -193,6 +194,7 @@ pub mod group_create {
         group_pub_key: internal::PublicKey,
         user_id: &'a UserId,
         member_transform_key: Option<internal::TransformKey>,
+        needs_rotation: bool,
     ) -> impl Future<Item = GroupBasicApiResponse, Error = IronOxideErr> + 'a {
         EncryptedOnceValue::try_from(re_encrypted_once_value)
             .into_future()
@@ -215,6 +217,7 @@ pub mod group_create {
                             user_master_public_key: user_master_pub_key.clone().into(),
                         }]
                     }),
+                    needs_rotation,
                 };
 
                 auth.request.post(

--- a/tests/document_ops.rs
+++ b/tests/document_ops.rs
@@ -96,6 +96,7 @@ fn doc_create_with_policy_grants() -> Result<(), IronOxideErr> {
         data_rec_group_id.clone().into(),
         None,
         true,
+        false,
     ));
     assert!(group_result.is_ok());
 
@@ -155,8 +156,12 @@ fn doc_create_with_policy_grants() -> Result<(), IronOxideErr> {
     let user2_result = create_second_user();
     let user2 = user2_result.account_id();
     let group2_id: GroupId = format!("group_other_{}", user2.id()).try_into().unwrap();
-    let group2_result =
-        sdk.group_create(&GroupCreateOpts::new(group2_id.clone().into(), None, false));
+    let group2_result = sdk.group_create(&GroupCreateOpts::new(
+        group2_id.clone().into(),
+        None,
+        false,
+        false,
+    ));
     assert!(group2_result.is_ok());
 
     let doc_result2 = sdk
@@ -343,6 +348,7 @@ fn setup_encrypt_with_explicit_and_policy_grants(
         data_rec_group_id.clone().into(),
         None,
         true,
+        false,
     ));
     assert!(group_result.is_ok());
 
@@ -657,7 +663,7 @@ fn doc_grant_access() {
     let group_id = group_result.unwrap().id().clone();
 
     // group user is not a member of
-    let group2_result = sdk.group_create(&GroupCreateOpts::new(None, None, false));
+    let group2_result = sdk.group_create(&GroupCreateOpts::new(None, None, false, false));
     assert!(group2_result.is_ok());
     let group2_id = group2_result.unwrap().id().clone();
 

--- a/tests/group_ops.rs
+++ b/tests/group_ops.rs
@@ -17,17 +17,21 @@ fn group_create_no_member() {
         Some(create_id_all_classes("").try_into().unwrap()),
         Some("test group name".try_into().unwrap()),
         false,
+        true,
     ));
 
-    assert_eq!(group_result.unwrap().needs_rotation(), Some(false))
+    assert_eq!(group_result.unwrap().needs_rotation(), Some(true))
 }
 
 #[test]
-fn group_create_also_member() {
+fn group_create_with_defaults() -> Result<(), IronOxideErr> {
     let sdk = init_sdk();
 
-    let group_result = sdk.group_create(&Default::default());
-    assert_eq!(group_result.unwrap().needs_rotation(), Some(false))
+    let result = sdk.group_create(&Default::default());
+    let group_result = result?;
+    assert_eq!(group_result.needs_rotation(), Some(false));
+    assert_eq!(group_result.is_member(), true);
+    Ok(())
 }
 
 #[test]
@@ -60,6 +64,7 @@ fn group_delete() {
         Some(create_id_all_classes("").try_into().unwrap()),
         None,
         true,
+        false,
     ));
     assert!(group_result.is_ok());
 
@@ -78,6 +83,7 @@ fn group_update_name() {
         .group_create(&GroupCreateOpts::new(
             Some(create_id_all_classes("").try_into().unwrap()),
             Some("first name".try_into().unwrap()),
+            false,
             false,
         ))
         .unwrap();
@@ -109,6 +115,7 @@ fn group_add_member() {
     let group_result = sdk.group_create(&GroupCreateOpts::new(
         Some(create_id_all_classes("").try_into().unwrap()),
         None,
+        false,
         false,
     ));
     assert!(group_result.is_ok());
@@ -153,6 +160,7 @@ fn group_remove_member() {
         Some(create_id_all_classes("").try_into().unwrap()),
         None,
         true,
+        false,
     ));
     assert!(group_result.is_ok());
     let group_id = group_result.unwrap().id().clone();
@@ -179,6 +187,7 @@ fn group_add_admin() {
     let group_result = sdk.group_create(&GroupCreateOpts::new(
         Some(create_id_all_classes("").try_into().unwrap()),
         None,
+        false,
         false,
     ));
     assert!(group_result.is_ok());
@@ -229,6 +238,7 @@ fn group_get_not_url_safe_id() {
     let group_create_result = sdk.group_create(&GroupCreateOpts::new(
         Some(not_url_safe_id.clone()),
         None,
+        false,
         false,
     ));
 


### PR DESCRIPTION
see #64 

Adds need_rotation to `GroupCreateOpts`, allowing a group to be created with its private key marked for rotation