### PR TITLE
[#61] Update release process

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,11 +2,13 @@ Release Checklist
 =================
 
 * Make sure all changes to be released are on `master`
-* Decide on the new version number (we use semver)
-* Write the CHANGELOG.md entry for the release by looking at the PRs
-* Commit `Cargo.toml` (for version number) and `CHANGELOG.md` to your local git. 
-  - paste changelog for the release into the commit message (For Github releases)
+* Compare `master`'s commit history to the change log to ensure all public API changes are included as well as notable internal changes
+* Sanity check the version number set in `Cargo.toml` with the change log. Remember, we use semver!
+* Commit `Cargo.toml` (if needed) and `CHANGELOG.md` to your local git. 
+  - paste change log for the release into the commit message (For Github releases)
 * `cargo package` to see if there are any issues
-* `git tag <NEW_VER_NUM> && git push origin <NEW_VER_NUM> && git push` (eg: 0.5.2)
+* Tag the release, using the changelog entry as the commit message
+  - `git tag -a <NEW_VER_NUM>`
+  - `git push origin <NEW_VER_NUM> && git push` (eg: 0.5.2)
 * `cargo publish`
 * Check crates.io and docs.rs sites for new version


### PR DESCRIPTION
see #61 

This is my proposal for what we should do for releases. 
In short
* change log entries are added during the PR process for individual changes
* the version number will be changed at part of the PR process, if needed. If a previous PR has already bumpd the minor version number, subsequent PRs don't need to change the version number.
* `git tag -a` should be used to tag the release with the current release's change log entry as the commit message. This commit message will appear on github releases.