### PR TITLE
Add members on group create

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 before_cache:
   - rm -rf /home/travis/.cargo/registry
 rust:
-  - 1.38.0
+  - 1.39.0
 branches:
   only:
     - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.14.0 (Unreleased)
 
+- [[#72](https://github.com/IronCoreLabs/ironoxide/pull/72)]
+  - Allows adding members at group creation time
 - [[#69](https://github.com/IronCoreLabs/ironoxide/pull/69)]
   - Allows changing of IronCore environment at runtime.
 - [[#64](https://github.com/IronCoreLabs/ironoxide/pull/64)]

--- a/src/group.rs
+++ b/src/group.rs
@@ -57,15 +57,18 @@ impl GroupCreateOpts {
     }
 
     fn standardize(self, calling_id: &UserId) -> GroupCreateOpts {
-        let mut new_members = self.members.clone();
-        if self.add_as_member && !self.members.contains(calling_id) {
-            new_members.push(calling_id.clone());
-        }
+        let standardized_members = if self.add_as_member && !self.members.contains(calling_id) {
+            let mut members = self.members.clone();
+            members.push(calling_id.clone());
+            members
+        } else {
+            self.members
+        };
         GroupCreateOpts::new(
             self.id,
             self.name,
             self.add_as_member,
-            new_members,
+            standardized_members,
             self.needs_rotation,
         )
     }

--- a/src/group.rs
+++ b/src/group.rs
@@ -1,6 +1,6 @@
 pub use crate::internal::group_api::{
-    GroupAccessEditErr, GroupAccessEditResult, GroupGetResult, GroupId, GroupListResult,
-    GroupMetaResult, GroupName,
+    GroupAccessEditErr, GroupAccessEditResult, GroupCreateResult, GroupGetResult, GroupId,
+    GroupListResult, GroupMetaResult, GroupName,
 };
 use crate::{
     internal::{group_api, user_api::UserId},
@@ -18,6 +18,9 @@ pub struct GroupCreateOpts {
     // true (default) - creating user will be added to the group's membership (in addition to being the group's admin);
     // false - creating user will not be added to the group's membership
     add_as_member: bool,
+    // list of users to add as members to the group.
+    // note: even if `add_as_member` is false, the calling user will be added as a member if they are in this list.
+    members: Vec<UserId>,
     // true - group's private key will be marked for rotation
     // false (default) - group's private key will not be marked for rotation
     needs_rotation: bool,
@@ -39,12 +42,14 @@ impl GroupCreateOpts {
         id: Option<GroupId>,
         name: Option<GroupName>,
         add_as_member: bool,
+        members: Vec<UserId>,
         needs_rotation: bool,
     ) -> GroupCreateOpts {
         GroupCreateOpts {
             id,
             name,
             add_as_member,
+            members,
             needs_rotation,
         }
     }
@@ -53,7 +58,7 @@ impl GroupCreateOpts {
 impl Default for GroupCreateOpts {
     fn default() -> Self {
         // membership is the default!
-        GroupCreateOpts::new(None, None, true, false)
+        GroupCreateOpts::new(None, None, true, Vec::new(), false)
     }
 }
 
@@ -68,7 +73,7 @@ pub trait GroupOps {
     ///
     /// # Arguments
     /// `group_create_opts` - See `GroupCreateOpts`. Use the `Default` implementation for defaults.
-    fn group_create(&self, group_create_opts: &GroupCreateOpts) -> Result<GroupMetaResult>;
+    fn group_create(&self, group_create_opts: &GroupCreateOpts) -> Result<GroupCreateResult>;
 
     /// Get the full metadata for a specific group given its ID.
     ///
@@ -157,14 +162,26 @@ impl GroupOps for crate::IronOxide {
         rt.block_on(group_api::list(self.device.auth(), None))
     }
 
-    fn group_create(&self, opts: &GroupCreateOpts) -> Result<GroupMetaResult> {
+    fn group_create(&self, opts: &GroupCreateOpts) -> Result<GroupCreateResult> {
         let mut rt = Runtime::new().unwrap();
         let GroupCreateOpts {
             id: maybe_id,
             name: maybe_name,
             add_as_member,
+            members,
             needs_rotation,
         } = opts.clone();
+
+        let modified_add_as_member;
+        if members.contains(self.device.auth().account_id()) {
+            modified_add_as_member = true;
+        } else {
+            modified_add_as_member = add_as_member;
+        }
+        let modified_members: Vec<UserId> = members
+            .into_iter()
+            .filter(|id| id.id() != self.device.auth().account_id().id())
+            .collect();
 
         rt.block_on(group_api::group_create(
             &self.recrypt,
@@ -172,7 +189,8 @@ impl GroupOps for crate::IronOxide {
             &self.user_master_pub_key,
             maybe_id,
             maybe_name,
-            add_as_member,
+            modified_add_as_member,
+            &modified_members,
             needs_rotation,
         ))
     }

--- a/src/internal/group_api/mod.rs
+++ b/src/internal/group_api/mod.rs
@@ -370,7 +370,6 @@ pub fn group_create<'a, CR: rand::CryptoRng + rand::RngCore>(
     user_master_pub_key: &'a PublicKey,
     group_id: Option<GroupId>,
     name: Option<GroupName>,
-    add_as_member: bool, // this could be used to add the caller to the member list after the `user_key_list` call if we can move the group.rs code here
     members: &'a Vec<UserId>,
     needs_rotation: bool,
 ) -> impl Future<Item = GroupCreateResult, Error = IronOxideErr> + 'a {

--- a/src/internal/group_api/mod.rs
+++ b/src/internal/group_api/mod.rs
@@ -408,10 +408,6 @@ pub fn group_create<'a, CR: rand::CryptoRng + rand::RngCore>(
                         let mut member_info = maybe_member_info?;
 
                         if add_as_member {
-                            // TODO (question for reviewers): is it better to have this code duplication here,
-                            // or to add the calling UserId to members list earlier and just have the public key
-                            // looked up with all the others (even though it was already passed in) to make
-                            // it cleaner?
                             let transform: TransformKey = recrypt
                                 .generate_transform_key(
                                     &group_priv_key.into(),

--- a/src/internal/group_api/mod.rs
+++ b/src/internal/group_api/mod.rs
@@ -359,8 +359,6 @@ pub(crate) fn get_group_keys<'a>(
 /// `user_master_pub_key` - public key of the user creating this group.
 /// `group_id` - unique id for the group within the segment.
 /// `name` - name for the group. Does not need to be unique.
-/// `add_as_member` - if true the user represented by the current DeviceContext will also be added to the group's membership.
-///     If false, the user will not be an member (but will still be an admin)
 /// `members` - list of user ids to add as members of the group. This list takes priority over `add_as_member`,
 ///     so the calling user will be added as a member if their id is in this list even if `add_as_member` is false.
 /// `needs_rotation` - true if the group private key should be rotated by an admin, else false

--- a/src/internal/group_api/requests.rs
+++ b/src/internal/group_api/requests.rs
@@ -246,11 +246,14 @@ pub mod group_create {
                 let req_members = member_info.map(|member| {
                     member
                         .into_iter()
-                        .map(|(mem_id, (mem_pub_key, mem_trans_key))| GroupMember {
-                            user_id: mem_id,
-                            transform_key: mem_trans_key.unwrap().into(), // we can unwrap because we know all members had it calculated
-                            user_master_public_key: mem_pub_key.into(),
+                        .map(|(mem_id, (mem_pub_key, maybe_trans_key))| {
+                            maybe_trans_key.map(|mem_trans_key| GroupMember {
+                                user_id: mem_id,
+                                transform_key: mem_trans_key.into(),
+                                user_master_public_key: mem_pub_key.into(),
+                            })
                         })
+                        .flatten()
                         .collect()
                 });
                 let req = GroupCreateReq {

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -431,7 +431,7 @@ pub fn user_key_list<'a>(
     )
 }
 
-///Get the keys for users. The result should be either a failure for a specific UserId (Left) or the id with their public key (Right).
+/// Get the keys for users. The result should be either a failure for a specific UserId (Left) or the id with their public key (Right).
 /// The resulting lists will have the same combined size as the incoming list.
 /// Calling this with an empty `users` list will not result in a call to the server.
 pub(crate) fn get_user_keys<'a>(

--- a/src/internal/user_api/requests.rs
+++ b/src/internal/user_api/requests.rs
@@ -15,7 +15,10 @@ use crate::{
     },
 };
 use chrono::Utc;
-use futures::Future;
+use futures::{
+    future::{Either, IntoFuture},
+    Future,
+};
 use std::convert::TryFrom;
 
 use crate::internal::auth_v2::AuthV2Builder;
@@ -291,13 +294,16 @@ pub mod user_key_list {
         users: &Vec<UserId>,
     ) -> impl Future<Item = UserKeyListResponse, Error = IronOxideErr> + 'a {
         let user_ids: Vec<&str> = users.iter().map(|user| user.id()).collect();
-
-        auth.request.get_with_query_params(
-            "users".into(),
-            &vec![("id".into(), rest::url_encode(&user_ids.join(",")))],
-            RequestErrorCode::UserKeyList,
-            AuthV2Builder::new(&auth, Utc::now()),
-        )
+        if user_ids.len() != 0 {
+            Either::A(auth.request.get_with_query_params(
+                "users".into(),
+                &vec![("id".into(), rest::url_encode(&user_ids.join(",")))],
+                RequestErrorCode::UserKeyList,
+                AuthV2Builder::new(&auth, Utc::now()),
+            ))
+        } else {
+            Either::B(Ok(UserKeyListResponse { result: Vec::new() }).into_future())
+        }
     }
 }
 

--- a/src/internal/user_api/requests.rs
+++ b/src/internal/user_api/requests.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 use chrono::Utc;
 use futures::{
-    future::{Either, IntoFuture},
+    future::{ok, Either},
     Future,
 };
 use std::convert::TryFrom;
@@ -302,7 +302,7 @@ pub mod user_key_list {
                 AuthV2Builder::new(&auth, Utc::now()),
             ))
         } else {
-            Either::B(Ok(UserKeyListResponse { result: Vec::new() }).into_future())
+            Either::B(ok(UserKeyListResponse { result: Vec::new() }))
         }
     }
 }

--- a/tests/group_ops.rs
+++ b/tests/group_ops.rs
@@ -17,6 +17,7 @@ fn group_create_no_member() {
         Some(create_id_all_classes("").try_into().unwrap()),
         Some("test group name".try_into().unwrap()),
         false,
+        Vec::new(),
         true,
     ));
 
@@ -64,6 +65,7 @@ fn group_delete() {
         Some(create_id_all_classes("").try_into().unwrap()),
         None,
         true,
+        Vec::new(),
         false,
     ));
     assert!(group_result.is_ok());
@@ -84,6 +86,7 @@ fn group_update_name() {
             Some(create_id_all_classes("").try_into().unwrap()),
             Some("first name".try_into().unwrap()),
             false,
+            Vec::new(),
             false,
         ))
         .unwrap();
@@ -116,6 +119,7 @@ fn group_add_member() {
         Some(create_id_all_classes("").try_into().unwrap()),
         None,
         false,
+        Vec::new(),
         false,
     ));
     assert!(group_result.is_ok());
@@ -134,6 +138,26 @@ fn group_add_member() {
     let add_member_res_second_unwrap = add_member_res_second.unwrap();
     assert_eq!(add_member_res_second_unwrap.succeeded().len(), 0);
     assert_eq!(add_member_res_second_unwrap.failed().len(), 2);
+}
+
+#[test]
+fn group_add_member_on_create() -> Result<(), IronOxideErr> {
+    let sdk = init_sdk();
+    let account_id = sdk.device().account_id().clone();
+    let second_account_id = init_sdk().device().account_id().clone();
+
+    // Even though `add_as_member` is false, the UserId is in the `members` list,
+    // so the caller becomes a member regardless
+    let group_result = sdk.group_create(&GroupCreateOpts::new(
+        Some(create_id_all_classes("").try_into().unwrap()),
+        None,
+        false,
+        vec![account_id.clone(), second_account_id.clone()],
+        false,
+    ))?;
+
+    assert_eq!(group_result.members(), &vec![second_account_id, account_id]);
+    Ok(())
 }
 
 #[test]
@@ -160,6 +184,7 @@ fn group_remove_member() {
         Some(create_id_all_classes("").try_into().unwrap()),
         None,
         true,
+        Vec::new(),
         false,
     ));
     assert!(group_result.is_ok());
@@ -188,6 +213,7 @@ fn group_add_admin() {
         Some(create_id_all_classes("").try_into().unwrap()),
         None,
         false,
+        Vec::new(),
         false,
     ));
     assert!(group_result.is_ok());
@@ -239,6 +265,7 @@ fn group_get_not_url_safe_id() {
         Some(not_url_safe_id.clone()),
         None,
         false,
+        Vec::new(),
         false,
     ));
 

--- a/tests/group_ops.rs
+++ b/tests/group_ops.rs
@@ -156,7 +156,7 @@ fn group_add_member_on_create() -> Result<(), IronOxideErr> {
         false,
     ))?;
 
-    assert_eq!(group_result.members(), &vec![second_account_id, account_id]);
+    assert_eq!(group_result.members(), &vec![account_id, second_account_id]);
     Ok(())
 }
 

--- a/tests/group_ops.rs
+++ b/tests/group_ops.rs
@@ -142,6 +142,7 @@ fn group_add_member() {
 
 #[test]
 fn group_add_member_on_create() -> Result<(), IronOxideErr> {
+    use std::{collections::HashSet, iter::FromIterator};
     let sdk = init_sdk();
     let account_id = sdk.device().account_id().clone();
     let second_account_id = init_sdk().device().account_id().clone();
@@ -156,7 +157,12 @@ fn group_add_member_on_create() -> Result<(), IronOxideErr> {
         false,
     ))?;
 
-    assert_eq!(group_result.members(), &vec![account_id, second_account_id]);
+    // the order if the vector can be confusing with the add_as_member, so comparing the
+    // sets can avoid issues with it
+    let result_set: HashSet<&UserId> = HashSet::from_iter(group_result.members());
+    let expected_vec = &vec![account_id, second_account_id];
+    let expected_set: HashSet<&UserId> = HashSet::from_iter(expected_vec);
+    assert_eq!(result_set, expected_set);
     Ok(())
 }
 

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -12,11 +12,10 @@ use uuid::Uuid;
 extern crate serde_json;
 
 #[test]
-fn user_verify_non_existing_user() {
-    let result = IronOxide::user_verify(&gen_jwt(None).0);
-    assert_eq!(true, result.is_ok(), "User verify call failed unexpectedly");
-    let option_result = result.unwrap();
+fn user_verify_non_existing_user() -> Result<(), IronOxideErr> {
+    let option_result = IronOxide::user_verify(&gen_jwt(None).0)?;
     assert_eq!(true, option_result.is_none());
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
- Made `GroupCreateOpts` contain a list of `UserIds` that should be added as members to the group. `group_create()` will fail if one of these `UserIds` cannot be found.
- Made `group_create()` return a `GroupCreateApiResponse` with a `try_into()` for a new `GroupCreateResult`. This result is similar to `GroupMetaResult` but includes a list of group admins and members.
- Added a test for adding members on create with the `members` list.
- Changed some tests to return Results and use `?` instead of `unwrap()` to get better error messages.

TODO:
- [x] Changelog
- [x] Discuss TODO questions aimed at reviewers