### PR TITLE
[#73] Converts internal user api and user/requests to async fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,6 @@ reqwest = "~0.9"
 reqwest10 = {package = "reqwest", version = "0.10.0-alpha.2"}
 tokio = "~0.1"
 futures3 = {package = "futures", version = "0.3.1", features = ["compat"]}
-futures-util = "0.3.1"
 hex = "~0.3"
 itertools = "~0.8"
 futures = "~0.1.25"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,10 @@ regex = "~1.1"
 ring = { version= "~0.16", features = ["std"] }
 recrypt = "~0.9" 
 reqwest = "~0.9"
+reqwest10 = {package = "reqwest", version = "0.10.0-alpha.2"}
 tokio = "~0.1"
+futures3 = {package = "futures", version = "0.3.1", features = ["compat"]}
+futures-util = "0.3.1"
 hex = "~0.3"
 itertools = "~0.8"
 futures = "~0.1.25"

--- a/src/internal/group_api/mod.rs
+++ b/src/internal/group_api/mod.rs
@@ -371,7 +371,11 @@ pub fn group_create<'a, CR: rand::CryptoRng + rand::RngCore>(
     members: &'a Vec<UserId>,
     needs_rotation: bool,
 ) -> impl Future<Item = GroupCreateResult, Error = IronOxideErr> + 'a {
+    use futures3::TryFutureExt;
+    use futures_util::future::FutureExt;
     user_api::user_key_list(auth, members)
+        .boxed()
+        .compat()
         .and_then(move |member_ids_and_keys| {
             // this will occur when one of the UserIds in the members list cannot be found
             if member_ids_and_keys.len() != members.len() {

--- a/src/internal/rest.rs
+++ b/src/internal/rest.rs
@@ -871,11 +871,10 @@ impl From<(publicsuffix::errors::Error, RequestErrorCode)> for IronOxideErr {
     }
 }
 
-//impl From
-
 /// Common types for use across different internal apis
 pub mod json {
-    use crate::internal::{self, IronOxideErr, TryFrom};
+    use crate::internal::{self, IronOxideErr};
+    use std::convert::TryFrom;
 
     base64_serde_type!(pub Base64Standard, base64::STANDARD);
 

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -398,13 +398,13 @@ pub async fn device_list(auth: &RequestAuth) -> Result<UserDeviceListResult, Iro
     }
 }
 
-pub fn device_delete<'a>(
+pub async fn device_delete<'a>(
     auth: &'a RequestAuth,
     device_id: Option<&'a DeviceId>,
-) -> impl Future<Item = DeviceId, Error = IronOxideErr> + 'a {
+) -> Result<DeviceId, IronOxideErr> {
     match device_id {
-        Some(device_id) => requests::device_delete::device_delete(auth, device_id),
-        None => requests::device_delete::device_delete_current(auth),
+        Some(device_id) => requests::device_delete::device_delete(auth, device_id).await,
+        None => requests::device_delete::device_delete_current(auth).await,
     }
     .map(|resp| resp.id)
 }

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -226,7 +226,7 @@ pub async fn user_create<CR: rand::CryptoRng + rand::RngCore>(
                 .map(|encrypted_private_key| (encrypted_private_key, recrypt_pub))?)
             })
     }
-    .await?;
+        .await?;
 
     requests::user_create::user_create(
         &jwt,

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -396,15 +396,14 @@ pub fn generate_device_key<'a, CR: rand::CryptoRng + rand::RngCore>(
         })
 }
 
-pub fn device_list(
-    auth: &RequestAuth,
-) -> impl Future<Item = UserDeviceListResult, Error = IronOxideErr> + '_ {
-    requests::device_list::device_list(auth).map(|resp| {
+pub async fn device_list(auth: &RequestAuth) -> Result<UserDeviceListResult, IronOxideErr> {
+    let resp = requests::device_list::device_list(auth).await?;
+    {
         let mut vec: Vec<UserDevice> = resp.result.into_iter().map(UserDevice::from).collect();
         // sort the devices by device_id
         vec.sort_by(|a, b| a.id.0.cmp(&b.id.0));
-        UserDeviceListResult::new(vec)
-    })
+        Ok(UserDeviceListResult::new(vec))
+    }
 }
 
 pub fn device_delete<'a>(

--- a/src/internal/user_api/requests.rs
+++ b/src/internal/user_api/requests.rs
@@ -157,14 +157,15 @@ pub mod user_get {
         pub(in crate::internal) groups_needing_rotation: Vec<String>,
     }
 
-    pub fn get_curr_user(
-        auth: &RequestAuth,
-    ) -> impl Future<Item = CurrentUserResponse, Error = IronOxideErr> + '_ {
-        auth.request.get(
-            "users/current",
-            RequestErrorCode::UserGetCurrent,
-            AuthV2Builder::new(&auth, Utc::now()),
-        )
+    pub async fn get_curr_user(auth: &RequestAuth) -> Result<CurrentUserResponse, IronOxideErr> {
+        auth.request
+            .get(
+                "users/current",
+                RequestErrorCode::UserGetCurrent,
+                AuthV2Builder::new(&auth, Utc::now()),
+            )
+            .compat()
+            .await
     }
 }
 
@@ -198,26 +199,29 @@ pub mod user_update_private_key {
         }
     }
 
-    pub fn update_private_key<'a>(
-        auth: &'a RequestAuth,
+    pub async fn update_private_key(
+        auth: &RequestAuth,
         user_id: UserId,
         user_key_id: u64,
         new_encrypted_private_key: EncryptedPrivateKey,
         augmenting_key: AugmentationFactor,
-    ) -> impl Future<Item = UserUpdatePrivateKeyResponse, Error = IronOxideErr> + 'a {
-        auth.request.put(
-            &format!(
-                "users/{}/keys/{}",
-                rest::url_encode(user_id.id()),
-                user_key_id
-            ),
-            &UserUpdatePrivateKey {
-                user_private_key: new_encrypted_private_key,
-                augmentation_factor: augmenting_key,
-            },
-            RequestErrorCode::UserKeyUpdate,
-            AuthV2Builder::new(&auth, Utc::now()),
-        )
+    ) -> Result<UserUpdatePrivateKeyResponse, IronOxideErr> {
+        auth.request
+            .put(
+                &format!(
+                    "users/{}/keys/{}",
+                    rest::url_encode(user_id.id()),
+                    user_key_id
+                ),
+                &UserUpdatePrivateKey {
+                    user_private_key: new_encrypted_private_key,
+                    augmentation_factor: augmenting_key,
+                },
+                RequestErrorCode::UserKeyUpdate,
+                AuthV2Builder::new(&auth, Utc::now()),
+            )
+            .compat()
+            .await
     }
 }
 

--- a/src/internal/user_api/requests.rs
+++ b/src/internal/user_api/requests.rs
@@ -71,15 +71,16 @@ pub mod user_verify {
         pub(crate) needs_rotation: bool,
     }
 
-    pub fn user_verify(
-        jwt: &Jwt,
-        request: &IronCoreRequest,
-    ) -> impl Future<Item = Option<UserVerifyResponse>, Error = IronOxideErr> {
+    pub async fn user_verify<'a>(
+        jwt: &'a Jwt,
+        request: &'a IronCoreRequest<'static>,
+    ) -> Result<Option<UserVerifyResponse>, IronOxideErr> {
+        use futures3::compat::*;
         request.get_with_empty_result_jwt_auth(
             "users/verify?returnKeys=true",
             RequestErrorCode::UserVerify,
             &Authorization::JwtAuth(jwt),
-        )
+        ).compat().await
     }
 
     impl TryFrom<UserVerifyResponse> for UserResult {

--- a/src/internal/user_api/requests.rs
+++ b/src/internal/user_api/requests.rs
@@ -431,31 +431,37 @@ pub mod device_delete {
         pub(crate) id: DeviceId,
     }
 
-    pub fn device_delete<'a>(
-        auth: &'a RequestAuth,
+    pub async fn device_delete(
+        auth: &RequestAuth,
         device_id: &DeviceId,
-    ) -> Box<dyn Future<Item = DeviceDeleteResponse, Error = IronOxideErr> + 'a> {
-        Box::new(auth.request.delete_with_no_body(
-            &format!(
-                "users/{}/devices/{}",
-                rest::url_encode(&auth.account_id().0),
-                device_id.0
-            ),
-            RequestErrorCode::UserDeviceDelete,
-            AuthV2Builder::new(&auth, Utc::now()),
-        ))
+    ) -> Result<DeviceDeleteResponse, IronOxideErr> {
+        auth.request
+            .delete_with_no_body(
+                &format!(
+                    "users/{}/devices/{}",
+                    rest::url_encode(&auth.account_id().0),
+                    device_id.0
+                ),
+                RequestErrorCode::UserDeviceDelete,
+                AuthV2Builder::new(&auth, Utc::now()),
+            )
+            .compat()
+            .await
     }
 
-    pub fn device_delete_current(
+    pub async fn device_delete_current(
         auth: &RequestAuth,
-    ) -> Box<dyn Future<Item = DeviceDeleteResponse, Error = IronOxideErr> + '_> {
-        Box::new(auth.request.delete_with_no_body(
-            &format!(
-                "users/{}/devices/current",
-                rest::url_encode(&auth.account_id().0)
-            ),
-            RequestErrorCode::UserDeviceDelete,
-            AuthV2Builder::new(&auth, Utc::now()),
-        ))
+    ) -> Result<DeviceDeleteResponse, IronOxideErr> {
+        auth.request
+            .delete_with_no_body(
+                &format!(
+                    "users/{}/devices/current",
+                    rest::url_encode(&auth.account_id().0)
+                ),
+                RequestErrorCode::UserDeviceDelete,
+                AuthV2Builder::new(&auth, Utc::now()),
+            )
+            .compat()
+            .await
     }
 }

--- a/src/internal/user_api/requests.rs
+++ b/src/internal/user_api/requests.rs
@@ -15,7 +15,6 @@ use crate::{
     },
 };
 use chrono::Utc;
-use futures::Future;
 use futures3::compat::Future01CompatExt;
 use std::convert::TryFrom;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,32 +148,37 @@ impl PrivateKeyRotationCheckResult {
 /// keys are valid and exist for the provided account. If successful returns an instance of the IronOxide SDK
 pub fn initialize(device_context: &DeviceContext) -> Result<IronOxide> {
     let mut rt = Runtime::new().unwrap();
-    rt.block_on(crate::internal::user_api::user_get_current(
-        &device_context.auth(),
-    ))
+    rt.block_on(
+        crate::internal::user_api::user_get_current(&device_context.auth())
+            .boxed()
+            .compat(),
+    )
     .map(|current_user| IronOxide::create(&current_user, device_context))
     .map_err(|_| IronOxideErr::InitializeError)
 }
-
+use futures3::future::{FutureExt, TryFutureExt};
 /// Initialize the IronOxide SDK and check to see if the user that owns this `DeviceContext` is
 /// marked for private key rotation, or if any of the groups that the user is an admin of is marked
 /// for private key rotation.
 pub fn initialize_check_rotation(device_context: &DeviceContext) -> Result<InitAndRotationCheck> {
     Runtime::new().unwrap().block_on(
-        internal::user_api::user_get_current(device_context.auth()).and_then(|curr_user| {
-            let ironoxide = IronOxide::create(&curr_user, &device_context);
+        internal::user_api::user_get_current(device_context.auth())
+            .boxed()
+            .compat()
+            .and_then(|curr_user| {
+                let ironoxide = IronOxide::create(&curr_user, &device_context);
 
-            if curr_user.needs_rotation() {
-                Ok(InitAndRotationCheck::RotationNeeded(
-                    ironoxide,
-                    PrivateKeyRotationCheckResult {
-                        rotations_needed: EitherOrBoth::Left(curr_user.account_id().clone()),
-                    },
-                ))
-            } else {
-                Ok(InitAndRotationCheck::NoRotationNeeded(ironoxide))
-            }
-        }),
+                if curr_user.needs_rotation() {
+                    Ok(InitAndRotationCheck::RotationNeeded(
+                        ironoxide,
+                        PrivateKeyRotationCheckResult {
+                            rotations_needed: EitherOrBoth::Left(curr_user.account_id().clone()),
+                        },
+                    ))
+                } else {
+                    Ok(InitAndRotationCheck::NoRotationNeeded(ironoxide))
+                }
+            }),
     )
 }
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -215,7 +215,11 @@ impl UserOps for IronOxide {
 
     fn user_get_public_key(&self, users: &[UserId]) -> Result<HashMap<UserId, PublicKey>> {
         let mut rt = Runtime::new().unwrap();
-        rt.block_on(user_api::user_key_list(self.device.auth(), &users.to_vec()))
+        rt.block_on(
+            user_api::user_key_list(self.device.auth(), &users.to_vec())
+                .boxed()
+                .compat(),
+        )
     }
 
     fn user_rotate_private_key(&self, password: &str) -> Result<UserUpdatePrivateKeyResult> {

--- a/src/user.rs
+++ b/src/user.rs
@@ -197,7 +197,11 @@ impl UserOps for IronOxide {
 
     fn user_delete_device(&self, device_id: Option<&DeviceId>) -> Result<DeviceId> {
         let mut rt = Runtime::new().unwrap();
-        rt.block_on(user_api::device_delete(self.device.auth(), device_id))
+        rt.block_on(
+            user_api::device_delete(self.device.auth(), device_id)
+                .boxed_local() // required because something isn't Send; perhaps related to IronCoreRequest
+                .compat(),
+        )
     }
 
     fn user_verify(jwt: &str) -> Result<Option<UserResult>> {

--- a/src/user.rs
+++ b/src/user.rs
@@ -181,14 +181,18 @@ impl UserOps for IronOxide {
         let mut rt = Runtime::new().unwrap();
         let device_create_options = device_create_options.clone();
 
-        rt.block_on(user_api::generate_device_key(
-            &recrypt,
-            &jwt.try_into()?,
-            password.try_into()?,
-            device_create_options.device_name,
-            &std::time::SystemTime::now().into(),
-            &OUR_REQUEST,
-        ))
+        rt.block_on(
+            user_api::generate_device_key(
+                &recrypt,
+                &jwt.try_into()?,
+                password.try_into()?,
+                device_create_options.device_name,
+                &std::time::SystemTime::now().into(),
+                &OUR_REQUEST,
+            )
+            .boxed()
+            .compat(),
+        )
     }
 
     fn user_delete_device(&self, device_id: Option<&DeviceId>) -> Result<DeviceId> {

--- a/src/user.rs
+++ b/src/user.rs
@@ -150,13 +150,17 @@ impl UserOps for IronOxide {
     ) -> Result<UserCreateResult> {
         let recrypt = Recrypt::new();
         let mut rt = Runtime::new().unwrap();
-        rt.block_on(user_api::user_create(
-            &recrypt,
-            jwt.try_into()?,
-            password.try_into()?,
-            user_create_opts.needs_rotation,
-            *OUR_REQUEST,
-        ))
+        rt.block_on(
+            user_api::user_create(
+                &recrypt,
+                jwt.try_into()?,
+                password.try_into()?,
+                user_create_opts.needs_rotation,
+                *OUR_REQUEST,
+            )
+            .boxed()
+            .compat(),
+        )
     }
 
     fn user_list_devices(&self) -> Result<UserDeviceListResult> {

--- a/src/user.rs
+++ b/src/user.rs
@@ -230,7 +230,7 @@ impl UserOps for IronOxide {
                 password.try_into()?,
                 self.device().auth(),
             )
-            .boxed_local()
+            .boxed_local() //required because something isn't Send...
             .compat(),
         )
     }

--- a/src/user.rs
+++ b/src/user.rs
@@ -224,11 +224,15 @@ impl UserOps for IronOxide {
 
     fn user_rotate_private_key(&self, password: &str) -> Result<UserUpdatePrivateKeyResult> {
         let mut rt = Runtime::new().unwrap();
-        rt.block_on(user_api::user_rotate_private_key(
-            &self.recrypt,
-            password.try_into()?,
-            self.device().auth(),
-        ))
+        rt.block_on(
+            user_api::user_rotate_private_key(
+                &self.recrypt,
+                password.try_into()?,
+                self.device().auth(),
+            )
+            .boxed_local()
+            .compat(),
+        )
     }
 }
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -165,7 +165,11 @@ impl UserOps for IronOxide {
 
     fn user_list_devices(&self) -> Result<UserDeviceListResult> {
         let mut rt = Runtime::new().unwrap();
-        rt.block_on(user_api::device_list(self.device.auth()))
+        rt.block_on(
+            user_api::device_list(self.device.auth())
+                .boxed_local() // required because something isn't Send; perhaps related to IronCoreRequest
+                .compat(),
+        )
     }
 
     fn generate_new_device(


### PR DESCRIPTION
see #73 

Functions in the internal user API and request layer have been updated to use `async fn` instead of `impl Future` or `Box<dyn Future>`. Places outside of the user API that used user functions were not updated, but rather the new Futures were converted back to Futures 0.1. 

Note that `internal/user_api/mod.rs` and `internal/user_api/requests.rs` no longer import anything from the futures (0.1) crate.

The intent is to do the group_api, document_api, rest.rs in separate PRs.