### PR TITLE
Adds build profiles for dev, test, release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,20 @@ log = "~0.4"
 protobuf = {version = "~2.8", features = ["with-bytes"]}
 vec1 = "1.4.0"
 
+
+[profile.dev]
+opt-level = 2 # Build deps with optimization, don't build ourselves with optimization
+debug = true
+
+[profile.test]
+opt-level = 2 # Build deps with optimization, don't build ourselves with optimization
+debug = true
+
+[profile.release]
+opt-level = 3
+debug = false
+lto = true
+
 [dev-dependencies]
 frank_jwt = "~3.1.2"
 galvanic-assert = "~0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,11 @@ vec1 = "1.4.0"
 
 
 [profile.dev]
-opt-level = 2 # Build deps with optimization, don't build ourselves with optimization
+opt-level = 2
 debug = true
 
 [profile.test]
-opt-level = 2 # Build deps with optimization, don't build ourselves with optimization
+opt-level = 2
 debug = true
 
 [profile.release]


### PR DESCRIPTION
* For dev we do want to build our dependencies with optimization, but don't optimize ironoxide to keep the build times shorter.
* For test we want the same as dev.
* For release we want to fully optimize and try to remove code from the binary that we don't want.

This is identical to what we do in recrypt.