### PR TITLE
Implement rotate_all() for PrivateKeyRotationCheckResult

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ java/scala/src/test/resources/service-keys.conf.stage
 java/scala/src/test/resources/service-keys.conf.local
 .vscode
 src/proto/transform.rs
+benches/data/*.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.14.1 (unreleased)
+## 0.15.0 (unreleased)
 
 - [[#94](https://github.com/IronCoreLabs/ironoxide/pull/94)]
   - Adds rotate_all() to `PrivateKeyRotationCheckResult`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 0.14.1 (unreleased)
 
+- [[#94](https://github.com/IronCoreLabs/ironoxide/pull/94)]
+  - Adds rotate_all() to `PrivateKeyRotationCheckResult`
+  - Adds id() to `GroupUpdatePrivateKeyResult`
 - [[#91](https://github.com/IronCoreLabs/ironoxide/pull/91)]
   - Adds simple sharing of tokio runtime across device authenticated SDK calls
 - [[#90](https://github.com/IronCoreLabs/ironoxide/pull/90)]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironoxide"
-version = "0.14.1"
+version = "0.15.0"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/src/internal/group_api/mod.rs
+++ b/src/internal/group_api/mod.rs
@@ -532,10 +532,15 @@ pub async fn group_create<CR: rand::CryptoRng + rand::RngCore>(
 
 #[derive(Debug, Clone)]
 pub struct GroupUpdatePrivateKeyResult {
+    id: GroupId,
     needs_rotation: bool,
 }
 
 impl GroupUpdatePrivateKeyResult {
+    /// The id of the group that was rotated
+    pub fn id(&self) -> &GroupId {
+        &self.id
+    }
     /// True if this group's private key requires additional rotation
     pub fn needs_rotation(&self) -> bool {
         self.needs_rotation
@@ -633,7 +638,7 @@ pub async fn group_rotate_private_key<CR: rand::CryptoRng + rand::RngCore>(
         aug_factor,
     )
     .await
-    .map(|resp| resp.into())
+    .map(|resp| (resp, group_id.to_owned()).into())
 }
 
 /// Get the metadata for a group given its ID

--- a/src/internal/group_api/requests.rs
+++ b/src/internal/group_api/requests.rs
@@ -290,11 +290,12 @@ pub mod group_update_private_key {
         needs_rotation: bool,
     }
 
-    impl From<GroupUpdatePrivateKeyResponse> for GroupUpdatePrivateKeyResult {
-        fn from(resp: GroupUpdatePrivateKeyResponse) -> Self {
+    impl From<(GroupUpdatePrivateKeyResponse, GroupId)> for GroupUpdatePrivateKeyResult {
+        fn from(resp_and_id: (GroupUpdatePrivateKeyResponse, GroupId)) -> Self {
             // don't expose the current_key_id to the outside world until we need to
             GroupUpdatePrivateKeyResult {
-                needs_rotation: resp.needs_rotation,
+                id: resp_and_id.1,
+                needs_rotation: resp_and_id.0.needs_rotation,
             }
         }
     }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -1239,8 +1239,11 @@ pub(crate) mod test {
             InitAndRotationCheck::NoRotationNeeded(_) => panic!("user and group need rotation"),
             InitAndRotationCheck::RotationNeeded(_, rotation) => rotation,
         };
-        assert_eq!(rotation.group_rotation_needed(), Some(vec1![good_group_id]));
-        assert_eq!(rotation.user_rotation_needed(), Some(user_id));
+        assert_eq!(
+            rotation.group_rotation_needed(),
+            Some(&vec1![good_group_id])
+        );
+        assert_eq!(rotation.user_rotation_needed(), Some(&user_id));
         Ok(())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,10 @@ impl PrivateKeyRotationCheckResult {
         }
     }
 
+    /// Rotate the private key of the calling user and all groups they are an administrator of where needs_rotation is true.
+    /// Note that this function has the potential to take much longer than other functions, as rotation will be done
+    /// individually on each user/group. If rotation is only needed for a specific group, it is strongly recommended
+    /// to call group_rotate_private_key() instead.
     pub fn rotate_all(
         &self,
         ironoxide: &IronOxide,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,11 @@ impl PrivateKeyRotationCheckResult {
     /// Rotate the private key of the calling user and all groups they are an administrator of where needs_rotation is true.
     /// Note that this function has the potential to take much longer than other functions, as rotation will be done
     /// individually on each user/group. If rotation is only needed for a specific group, it is strongly recommended
-    /// to call group_rotate_private_key() instead.
+    /// to call [user_rotate_private_key()](user\/trait.UserOps.html#tymethod.user_rotate_private_key) or
+    /// [group_rotate_private_key()](group\/trait.GroupOps.html#tymethod.group_rotate_private_key) instead.
+    /// # Arguments
+    /// - `ironoxide` - IronOxide used to make authenticated requests for the calling user
+    /// - `password` - Password to unlock the current user's user master key
     pub fn rotate_all(
         &self,
         ironoxide: &IronOxide,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,8 +197,7 @@ impl PrivateKeyRotationCheckResult {
         let (user_opt_result, group_opt_vec_result) = ironoxide
             .runtime
             .block_on(futures::future::join(user_opt_future, group_opt_future));
-        let group_opt_result_vec =
-            group_opt_vec_result.map(|g| g.into_iter().collect::<Result<Vec<_>>>());
+        let group_opt_result_vec = group_opt_vec_result.map(|g| g.into_iter().collect());
         Ok((
             user_opt_result.transpose()?,
             group_opt_result_vec.transpose()?,

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -73,7 +73,7 @@
 //! groups [group_alice@ironcorelabs, data_recovery"]
 //!
 //! `PolicyGrant::new(None, None, None, None)` will match the last rule in the example and will return
-//! the group [data_recovery]
+//! the group \[data_recovery\]
 //!
 use crate::{internal::user_api::UserId, IronOxideErr, Result};
 use regex::Regex;

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -99,7 +99,7 @@ fn sdk_init_with_private_key_rotation() -> Result<(), IronOxideErr> {
     let _: IronOxide = match init_result {
         InitAndRotationCheck::NoRotationNeeded(_ironoxide) => panic!("user should need rotation"),
         InitAndRotationCheck::RotationNeeded(io, rotation_check) => {
-            assert_eq!(rotation_check.user_rotation_needed(), Some(user_id));
+            assert_eq!(rotation_check.user_rotation_needed(), Some(&user_id));
             let rotation_result = io.user_rotate_private_key(common::USER_PASSWORD)?;
             assert_eq!(rotation_result.needs_rotation(), false);
             io


### PR DESCRIPTION
These changes are so that ironoxide-java can make its `initialize_and_rotate()` function include all groups that need rotation. 
I also noticed that the GroupUpdatePrivateKeyResult only returning `needs_rotation` makes sense when you're calling the function yourself one-by-one, but a `rotate_all()` will return a vector of results, so it should include the `GroupId` to relate the result to the group.