### PR TITLE
[#93] Make async api the default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 before_cache:
   - rm -rf /home/travis/.cargo/registry
 rust:
-  - 1.40.0
+  - beta
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 before_cache:
   - rm -rf /home/travis/.cargo/registry
 rust:
-  - 1.39.0
+  - 1.40.0
 branches:
   only:
     - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ## 0.17.0 (Unreleased)
 
 - [[#101](https://github.com/IronCoreLabs/ironoxide/pull/101)]
-  - Dependecy upgrades
+  - Dependency upgrades
+- [[#97](https://github.com/IronCoreLabs/ironoxide/pull/97)]
+  - Make the default API async
 
 ## 0.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.15.0 (unreleased)
+## 0.15.0
 
 - [[#94](https://github.com/IronCoreLabs/ironoxide/pull/94)]
   - Adds rotate_all() to `PrivateKeyRotationCheckResult`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ description = "A pure-Rust SDK for accessing IronCore's privacy platform"
 edition = "2018"
 
 [dependencies]
+async-trait = "0.1.21"
 base64 = "~0.10"
 base64-serde = "~0.3.1"
 bytes = "~0.4.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ ring = { version= "~0.16", features = ["std"] }
 recrypt = "^0.9.2"
 url= "^2.1.0"
 reqwest = {version="0.10.0-alpha.2", features = ["json"]}
-tokio = "0.2.0-alpha.6"
 hex = "~0.3"
 itertools = "~0.8"
 futures = "~0.3.1"
@@ -59,6 +58,8 @@ galvanic-assert = "~0.8"
 uuid = { version = "~0.7.2", features = ["serde", "v4"] }
 double = "~0.2.4"
 criterion = "~0.3"
+tokio = "0.2.0-alpha.6"
+tokio-test = "0.2.0-alpha.6"
 
 [build-dependencies]
 protobuf-codegen-pure = "~2.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,8 @@ galvanic-assert = "~0.8"
 uuid = { version = "~0.7.2", features = ["serde", "v4"] }
 double = "~0.2.4"
 criterion = "~0.3"
-tokio = {version="~0.2.6", features = ["rt-threaded"]}
-tokio-test = "0.2.6"
+tokio = {version = "~0.2.0", features = ["full"]}
+tokio-test = "0.2.0"
 
 [build-dependencies]
 protobuf-codegen-pure = "~2.10"

--- a/benches/ironoxide_bench.rs
+++ b/benches/ironoxide_bench.rs
@@ -4,85 +4,120 @@ use ironoxide::{
     prelude::*,
     DeviceContext, IronOxide,
 };
+use tokio::runtime::Runtime;
 
 /// Setup for dev1 environment
-fn setup_dev() -> IronOxide {
+async fn setup_dev() -> IronOxide {
     let device_string = std::fs::read_to_string("benches/data/dev1-device1.json")
         .expect("device missing. Did you decrypt the .iron file?");
     let d: DeviceContext = serde_json::from_str(&device_string).expect("DeviceContext invalid");
-    ironoxide::initialize(&d).expect("ironoxide init failed")
+    ironoxide::initialize(&d)
+        .await
+        .expect("ironoxide init failed. Are you using IRONCORE_ENV=dev ?")
 }
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let io = setup_dev();
-    let data = [43u8; 100 * 1024]; //100KB of data
+    let rt = Runtime::new().expect("Tokio Runtime init failed");
+    let f = async {
+        let io = setup_dev().await;
+        let data = [43u8; 100 * 1024]; //100KB of data
 
-    // encrypted data to user to decrypt
-    let enc_result = io
-        .document_encrypt(&data, &Default::default())
-        .expect("encryption failed");
-    let enc_data = enc_result.encrypted_data();
+        // encrypted data to user to decrypt
+        let enc_result = io
+            .document_encrypt(&data, &Default::default())
+            .await
+            .expect("encryption failed");
+        let enc_data = enc_result.encrypted_data().to_vec();
 
-    // (unmanaged) encrypted data/deks to user to decrypt
-    let enc_result_unmanaged = io
-        .document_encrypt_unmanaged(&data, &Default::default())
-        .expect("encryption failed");
-    let (enc_data_unmanaged, enc_deks_unmanaged) = (
-        enc_result_unmanaged.encrypted_data(),
-        enc_result_unmanaged.encrypted_deks(),
-    );
+        // (unmanaged) encrypted data/deks to user to decrypt
+        let enc_result_unmanaged = io
+            .document_encrypt_unmanaged(&data, &Default::default())
+            .await
+            .expect("encryption failed");
+        let (enc_data_unmanaged, enc_deks_unmanaged) = (
+            enc_result_unmanaged.encrypted_data().to_vec(),
+            enc_result_unmanaged.encrypted_deks().to_vec(),
+        );
 
-    // group to encrypt to
-    let group_result = io
-        .group_create(&Default::default())
-        .expect("group creation failed");
-    let group = group_result.id();
+        // group to encrypt to
+        let group_result = io
+            .group_create(&Default::default())
+            .await
+            .expect("group creation failed");
+        let group = group_result.id();
 
-    // data encrypted to a group to decrypt
-    let group_enc_result = io
-        .document_encrypt_unmanaged(
-            &data,
-            &DocumentEncryptOpts::with_explicit_grants(None, None, false, vec![group.into()]),
+        // data encrypted to a group to decrypt
+        let group_enc_result = io
+            .document_encrypt_unmanaged(
+                &data,
+                &DocumentEncryptOpts::with_explicit_grants(None, None, false, vec![group.into()]),
+            )
+            .await
+            .expect("encrypt to group failed");
+        let (group_enc_data, group_enc_deks) = (
+            group_enc_result.encrypted_data().to_vec(),
+            group_enc_result.encrypted_deks().to_vec(),
+        );
+        (
+            io,
+            data,
+            enc_result,
+            enc_data,
+            enc_data_unmanaged,
+            enc_deks_unmanaged,
+            group_enc_data,
+            group_enc_deks,
         )
-        .expect("encrypt to group failed");
-    let (group_enc_data, group_enc_deks) = (
-        group_enc_result.encrypted_data(),
-        group_enc_result.encrypted_deks(),
-    );
+    };
+    let (
+        io,
+        data,
+        enc_result,
+        enc_data,
+        enc_data_unmanaged,
+        enc_deks_unmanaged,
+        group_enc_data,
+        group_enc_deks,
+    ) = rt.block_on(f);
 
     c.bench_function("document get metadata", |b| {
-        b.iter(|| io.document_get_metadata(black_box(enc_result.id())))
+        b.iter(|| rt.block_on(io.document_get_metadata(black_box(enc_result.id()))))
     });
 
     c.bench_function("document encrypt [self]", |b| {
-        b.iter(|| io.document_encrypt(black_box(&data), &Default::default()))
+        b.iter(|| rt.block_on(io.document_encrypt(black_box(&data), &Default::default())))
     });
 
     c.bench_function("document encrypt (unmanaged) [self]", |b| {
-        b.iter(|| io.document_encrypt_unmanaged(black_box(&data), &Default::default()))
+        b.iter(|| rt.block_on(io.document_encrypt_unmanaged(black_box(&data), &Default::default())))
     });
 
     c.bench_function("document decrypt [user]", |b| {
-        b.iter(|| io.document_decrypt(black_box(enc_data)))
+        b.iter(|| rt.block_on(io.document_decrypt(black_box(&enc_data))))
     });
 
     c.bench_function("document decrypt (unmanaged) [group]", |b| {
         b.iter(|| {
-            io.document_decrypt_unmanaged(black_box(&group_enc_data), black_box(&group_enc_deks))
+            rt.block_on(
+                io.document_decrypt_unmanaged(
+                    black_box(&group_enc_data),
+                    black_box(&group_enc_deks),
+                ),
+            )
         })
     });
 
     c.bench_function("document decrypt (unmanaged) [user]", |b| {
         b.iter(|| {
-            io.document_decrypt_unmanaged(
-                black_box(enc_data_unmanaged),
-                black_box(enc_deks_unmanaged),
-            )
+            rt.block_on(io.document_decrypt_unmanaged(
+                black_box(&enc_data_unmanaged),
+                black_box(&enc_deks_unmanaged),
+            ))
         })
     });
 
     c.bench_function("group create", |b| {
-        b.iter(|| io.group_create(black_box(&Default::default())))
+        b.iter(|| rt.block_on(io.group_create(black_box(&Default::default()))))
     });
 }
 

--- a/benches/ironoxide_bench.rs
+++ b/benches/ironoxide_bench.rs
@@ -78,46 +78,46 @@ fn criterion_benchmark(c: &mut Criterion) {
         enc_deks_unmanaged,
         group_enc_data,
         group_enc_deks,
-    ) = rt.block_on(f);
+    ) = rt.enter(|| futures::executor::block_on(f));
 
     c.bench_function("document get metadata", |b| {
-        b.iter(|| rt.block_on(io.document_get_metadata(black_box(enc_result.id()))))
+        b.iter(|| rt.enter(|| futures::executor::block_on(io.document_get_metadata(black_box(enc_result.id())))))
     });
 
     c.bench_function("document encrypt [self]", |b| {
-        b.iter(|| rt.block_on(io.document_encrypt(black_box(&data), &Default::default())))
+        b.iter(|| rt.enter(|| futures::executor::block_on(io.document_encrypt(black_box(&data), &Default::default()))))
     });
 
     c.bench_function("document encrypt (unmanaged) [self]", |b| {
-        b.iter(|| rt.block_on(io.document_encrypt_unmanaged(black_box(&data), &Default::default())))
+        b.iter(|| rt.enter(|| futures::executor::block_on(io.document_encrypt_unmanaged(black_box(&data), &Default::default()))))
     });
 
     c.bench_function("document decrypt [user]", |b| {
-        b.iter(|| rt.block_on(io.document_decrypt(black_box(&enc_data))))
+        b.iter(|| rt.enter(|| futures::executor::block_on(io.document_decrypt(black_box(&enc_data)))))
     });
 
     c.bench_function("document decrypt (unmanaged) [group]", |b| {
         b.iter(|| {
-            rt.block_on(
+            rt.enter(|| futures::executor::block_on(
                 io.document_decrypt_unmanaged(
                     black_box(&group_enc_data),
                     black_box(&group_enc_deks),
                 ),
-            )
+            ))
         })
     });
 
     c.bench_function("document decrypt (unmanaged) [user]", |b| {
         b.iter(|| {
-            rt.block_on(io.document_decrypt_unmanaged(
+            rt.enter(|| futures::executor::block_on(io.document_decrypt_unmanaged(
                 black_box(&enc_data_unmanaged),
                 black_box(&enc_deks_unmanaged),
-            ))
+            )))
         })
     });
 
     c.bench_function("group create", |b| {
-        b.iter(|| rt.block_on(io.group_create(black_box(&Default::default()))))
+        b.iter(|| rt.enter(|| futures::executor::block_on(io.group_create(black_box(&Default::default())))))
     });
 }
 

--- a/src/internal/group_api/requests.rs
+++ b/src/internal/group_api/requests.rs
@@ -199,7 +199,7 @@ pub mod group_list {
         let group_ids: Vec<&str> = groups.iter().map(|group| group.id()).collect();
         auth.request
             .get_with_query_params(
-                &format!("groups"),
+                "groups",
                 &vec![("id".into(), rest::url_encode(&group_ids.join(",")))],
                 RequestErrorCode::GroupList,
                 AuthV2Builder::new(&auth, Utc::now()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,8 @@ extern crate galvanic_assert;
 #[cfg(test)]
 #[macro_use]
 extern crate double;
-
+#[macro_use]
+extern crate async_trait;
 #[macro_use]
 extern crate percent_encoding;
 

--- a/src/user.rs
+++ b/src/user.rs
@@ -11,7 +11,6 @@ use crate::{
 };
 use recrypt::api::Recrypt;
 use std::{collections::HashMap, convert::TryInto};
-use tokio::runtime::current_thread::Runtime;
 
 /// Optional parameters for creating a new device instance.
 #[derive(Debug, PartialEq, Clone)]
@@ -57,6 +56,7 @@ impl Default for UserCreateOpts {
     }
 }
 
+#[async_trait]
 pub trait UserOps {
     /// Sync a new user within the IronCore system.
     ///
@@ -68,7 +68,7 @@ pub trait UserOps {
     /// Newly generated `UserCreateResult` or Err. For most use cases, this public key can
     /// be discarded as IronCore escrows your user's keys. The escrowed keys are unlocked
     /// by the provided password.
-    fn user_create(
+    async fn user_create(
         jwt: &str,
         password: &str,
         user_create_opts: &UserCreateOpts,
@@ -78,7 +78,7 @@ pub trait UserOps {
     ///
     /// # Returns
     /// All devices for the current user, sorted by the device id.
-    fn user_list_devices(&self) -> Result<UserDeviceListResult>;
+    async fn user_list_devices(&self) -> Result<UserDeviceListResult>;
 
     /// Generates a new device for the user specified in the signed JWT.
     ///
@@ -92,7 +92,7 @@ pub trait UserOps {
     ///
     /// # Returns
     /// Details about the newly created device.
-    fn generate_new_device(
+    async fn generate_new_device(
         jwt: &str,
         password: &str,
         device_create_options: &DeviceCreateOpts,
@@ -109,7 +109,7 @@ pub trait UserOps {
     ///
     /// # Returns
     /// Id of deleted device or IronOxideErr
-    fn user_delete_device(&self, device_id: Option<&DeviceId>) -> Result<DeviceId>;
+    async fn user_delete_device(&self, device_id: Option<&DeviceId>) -> Result<DeviceId>;
 
     /// Verify a user given a JWT for their user record.
     ///
@@ -118,7 +118,7 @@ pub trait UserOps {
     ///
     /// # Returns
     /// Option of whether the user's account record exists in the IronCore system or not. Err if the request couldn't be made.
-    fn user_verify(jwt: &str) -> Result<Option<UserResult>>;
+    async fn user_verify(jwt: &str) -> Result<Option<UserResult>>;
 
     /// Get a list of user public keys given their IDs. Allows discovery of which user IDs have keys in the
     /// IronCore system to determine of they can be added to groups or have documents shared with them.
@@ -128,7 +128,7 @@ pub trait UserOps {
     ///
     /// # Returns
     /// Map from user ID to users public key. Only users who have public keys will be returned in the map.
-    fn user_get_public_key(&self, users: &[UserId]) -> Result<HashMap<UserId, PublicKey>>;
+    async fn user_get_public_key(&self, users: &[UserId]) -> Result<HashMap<UserId, PublicKey>>;
 
     /// Rotate the current user's private key, but leave the public key the same.
     /// There's no black magic here! This is accomplished via multi-party computation with the
@@ -139,70 +139,66 @@ pub trait UserOps {
     ///
     /// # Returns
     /// The (encrypted) updated private key and associated metadata
-    fn user_rotate_private_key(&self, password: &str) -> Result<UserUpdatePrivateKeyResult>;
+    async fn user_rotate_private_key(&self, password: &str) -> Result<UserUpdatePrivateKeyResult>;
 }
+
+#[async_trait]
 impl UserOps for IronOxide {
-    fn user_create(
+    async fn user_create(
         jwt: &str,
         password: &str,
         user_create_opts: &UserCreateOpts,
     ) -> Result<UserCreateResult> {
         let recrypt = Recrypt::new();
-        let mut rt = Runtime::new().unwrap();
-        rt.block_on(user_api::user_create(
+        user_api::user_create(
             &recrypt,
             jwt.try_into()?,
             password.try_into()?,
             user_create_opts.needs_rotation,
             *OUR_REQUEST,
-        ))
+        )
+        .await
     }
 
-    fn user_list_devices(&self) -> Result<UserDeviceListResult> {
-        let mut rt = Runtime::new().unwrap();
-        rt.block_on(user_api::device_list(self.device.auth()))
+    async fn user_list_devices(&self) -> Result<UserDeviceListResult> {
+        user_api::device_list(self.device.auth()).await
     }
 
-    fn generate_new_device(
+    async fn generate_new_device(
         jwt: &str,
         password: &str,
         device_create_options: &DeviceCreateOpts,
     ) -> Result<DeviceContext> {
         let recrypt = Recrypt::new();
-        let mut rt = Runtime::new().unwrap();
+
         let device_create_options = device_create_options.clone();
 
-        rt.block_on(user_api::generate_device_key(
+        user_api::generate_device_key(
             &recrypt,
             &jwt.try_into()?,
             password.try_into()?,
             device_create_options.device_name,
             &std::time::SystemTime::now().into(),
             &OUR_REQUEST,
-        ))
+        )
+        .await
     }
 
-    fn user_delete_device(&self, device_id: Option<&DeviceId>) -> Result<DeviceId> {
-        self.runtime
-            .block_on(user_api::device_delete(self.device.auth(), device_id))
+    async fn user_delete_device(&self, device_id: Option<&DeviceId>) -> Result<DeviceId> {
+        user_api::device_delete(self.device.auth(), device_id).await
     }
 
-    fn user_verify(jwt: &str) -> Result<Option<UserResult>> {
-        let mut rt = Runtime::new().unwrap();
-        rt.block_on(user_api::user_verify(jwt.try_into()?, *OUR_REQUEST))
+    async fn user_verify(jwt: &str) -> Result<Option<UserResult>> {
+        user_api::user_verify(jwt.try_into()?, *OUR_REQUEST).await
     }
 
-    fn user_get_public_key(&self, users: &[UserId]) -> Result<HashMap<UserId, PublicKey>> {
-        self.runtime
-            .block_on(user_api::user_key_list(self.device.auth(), &users.to_vec()))
+    async fn user_get_public_key(&self, users: &[UserId]) -> Result<HashMap<UserId, PublicKey>> {
+        user_api::user_key_list(self.device.auth(), &users.to_vec()).await
     }
 
-    fn user_rotate_private_key(&self, password: &str) -> Result<UserUpdatePrivateKeyResult> {
-        self.runtime.block_on(user_api::user_rotate_private_key(
-            &self.recrypt,
-            password.try_into()?,
-            self.device().auth(),
-        ))
+    async fn user_rotate_private_key(&self, password: &str) -> Result<UserUpdatePrivateKeyResult> {
+        user_api::user_rotate_private_key(&self.recrypt, password.try_into()?, self.device().auth())
+            .await
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,3 @@
-use futures::Future;
 use ironoxide::{
     prelude::*,
     user::{UserCreateOpts, UserResult},
@@ -6,7 +5,6 @@ use ironoxide::{
 };
 use lazy_static::*;
 use std::{convert::TryInto, default::Default};
-use tokio::runtime::Runtime;
 use uuid::Uuid;
 
 pub const USER_PASSWORD: &str = "foo";
@@ -103,50 +101,46 @@ pub fn gen_jwt(account_id: Option<&str>) -> (String, String) {
     (jwt, sub.to_string())
 }
 
-// This function is similar to init_sdk_get_user, but is more streamlined
-// by not discarding InitAndRotationCheck, not calling user_verify for each
-// user_create, and not manually unwrapping/re-wrapping the DeviceContext.
-// The intent is that this will be used in most of the tests, as those extra
-// verifications are not the goal of most tests. It also returns a result to give
-// nice error handling with `?` in the tests.
-pub fn initialize_sdk() -> Result<IronOxide, IronOxideErr> {
+/// This function is similar to init_sdk_get_user, but is more streamlined
+/// by not discarding InitAndRotationCheck, not calling user_verify for each
+/// user_create, and not manually unwrapping/re-wrapping the DeviceContext.
+/// The intent is that this will be used in most of the tests, as those extra
+/// verifications are not the goal of most tests. It also returns a result to give
+/// nice error handling with `?` in the tests.
+pub async fn initialize_sdk() -> Result<IronOxide, IronOxideErr> {
     let account_id: UserId = create_id_all_classes("").try_into()?;
     IronOxide::user_create(
         &gen_jwt(Some(account_id.id())).0,
         USER_PASSWORD,
         &UserCreateOpts::new(false),
-    )?;
+    )
+    .await?;
     let device = IronOxide::generate_new_device(
         &gen_jwt(Some(account_id.id())).0,
         USER_PASSWORD,
         &Default::default(),
-    )?;
-    ironoxide::initialize(&device)
+    )
+    .await?;
+    ironoxide::initialize(&device).await
 }
 
-pub fn run_async<F>(f: F) -> F::Output
-where
-    F: Future,
-{
-    let rt = Runtime::new().unwrap();
-    rt.block_on(f)
-}
-
-pub fn init_sdk_get_user() -> (UserId, IronOxide) {
-    let (u, init_check) = init_sdk_get_init_result(false);
+pub async fn init_sdk_get_user() -> (UserId, IronOxide) {
+    let (u, init_check) = init_sdk_get_init_result(false).await;
     (u, init_check.discard_check())
 }
 
-pub fn init_sdk_get_init_result(user_needs_rotation: bool) -> (UserId, InitAndRotationCheck) {
+pub async fn init_sdk_get_init_result(user_needs_rotation: bool) -> (UserId, InitAndRotationCheck) {
     let account_id: UserId = create_id_all_classes("").try_into().unwrap();
     IronOxide::user_create(
         &gen_jwt(Some(account_id.id())).0,
         USER_PASSWORD,
         &UserCreateOpts::new(user_needs_rotation),
     )
+    .await
     .unwrap();
 
     let verify_resp = IronOxide::user_verify(&gen_jwt(Some(account_id.id())).0)
+        .await
         .unwrap()
         .unwrap();
     assert_eq!(&account_id, verify_resp.account_id());
@@ -156,6 +150,7 @@ pub fn init_sdk_get_init_result(user_needs_rotation: bool) -> (UserId, InitAndRo
         USER_PASSWORD,
         &Default::default(),
     )
+    .await
     .unwrap();
 
     //Manually unwrap all of these types and rewrap them just to prove that we can construct the DeviceContext
@@ -176,19 +171,21 @@ pub fn init_sdk_get_init_result(user_needs_rotation: bool) -> (UserId, InitAndRo
     );
     (
         account_id,
-        ironoxide::initialize_check_rotation(&device_init).unwrap(),
+        ironoxide::initialize_check_rotation(&device_init)
+            .await
+            .unwrap(),
     )
 }
 
 // this warns that it's unused because it's only used in other files,
 // so this is suppressed to avoid false positive.
 #[allow(dead_code)]
-pub fn create_second_user() -> UserResult {
+pub async fn create_second_user() -> UserResult {
     let (jwt, _) = gen_jwt(Some(&create_id_all_classes("")));
-    let create_result = IronOxide::user_create(&jwt, USER_PASSWORD, &Default::default());
+    let create_result = IronOxide::user_create(&jwt, USER_PASSWORD, &Default::default()).await;
     assert!(create_result.is_ok());
 
-    let verify_result = IronOxide::user_verify(&jwt);
+    let verify_result = IronOxide::user_verify(&jwt).await;
     assert!(verify_result.is_ok());
     verify_result.unwrap().unwrap()
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,4 @@
+use futures::Future;
 use ironoxide::{
     prelude::*,
     user::{UserCreateOpts, UserResult},
@@ -5,6 +6,7 @@ use ironoxide::{
 };
 use lazy_static::*;
 use std::{convert::TryInto, default::Default};
+use tokio::runtime::Runtime;
 use uuid::Uuid;
 
 pub const USER_PASSWORD: &str = "foo";
@@ -120,6 +122,14 @@ pub fn initialize_sdk() -> Result<IronOxide, IronOxideErr> {
         &Default::default(),
     )?;
     ironoxide::initialize(&device)
+}
+
+pub fn run_async<F>(f: F) -> F::Output
+where
+    F: Future,
+{
+    let rt = Runtime::new().unwrap();
+    rt.block_on(f)
 }
 
 pub fn init_sdk_get_user() -> (UserId, IronOxide) {

--- a/tests/group_ops.rs
+++ b/tests/group_ops.rs
@@ -1,5 +1,5 @@
 use crate::common::{create_second_user, gen_jwt, USER_PASSWORD};
-use common::{create_id_all_classes, init_sdk_get_user, initialize_sdk, run_async};
+use common::{create_id_all_classes, init_sdk_get_user, initialize_sdk};
 use ironoxide::{document::DocumentEncryptOpts, group::*, prelude::*};
 use std::convert::TryInto;
 use uuid::Uuid;
@@ -12,31 +12,33 @@ extern crate serde_json;
 #[macro_use]
 extern crate galvanic_assert;
 
-#[test]
-fn group_create_no_member() -> Result<(), IronOxideErr> {
-    let sdk = initialize_sdk()?;
+#[tokio::test]
+async fn group_create_no_member() -> Result<(), IronOxideErr> {
+    let sdk = initialize_sdk().await?;
 
-    let group_result = run_async(sdk.group_create(&GroupCreateOpts::new(
-        Some(create_id_all_classes("").try_into()?),
-        Some("test group name".try_into()?),
-        true,
-        false,
-        None,
-        vec![],
-        vec![],
-        true,
-    )))?;
+    let group_result = sdk
+        .group_create(&GroupCreateOpts::new(
+            Some(create_id_all_classes("").try_into()?),
+            Some("test group name".try_into()?),
+            true,
+            false,
+            None,
+            vec![],
+            vec![],
+            true,
+        ))
+        .await?;
 
     assert_eq!(group_result.owner(), sdk.device().account_id());
     assert_eq!(group_result.needs_rotation(), Some(true));
     Ok(())
 }
 
-#[test]
-fn group_create_with_defaults() -> Result<(), IronOxideErr> {
-    let sdk = initialize_sdk()?;
+#[tokio::test]
+async fn group_create_with_defaults() -> Result<(), IronOxideErr> {
+    let sdk = initialize_sdk().await?;
 
-    let result = run_async(sdk.group_create(&Default::default()));
+    let result = sdk.group_create(&Default::default()).await;
     let group_result = result?;
     assert_eq!(group_result.needs_rotation(), Some(false));
     assert!(group_result.is_member());
@@ -45,22 +47,24 @@ fn group_create_with_defaults() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
-#[test]
-fn group_init_and_rotation_check() -> Result<(), IronOxideErr> {
+#[tokio::test]
+async fn group_init_and_rotation_check() -> Result<(), IronOxideErr> {
     use ironoxide::InitAndRotationCheck;
     let user: UserId = create_id_all_classes("").try_into()?;
     IronOxide::user_create(
         &gen_jwt(Some(user.id())).0,
         USER_PASSWORD,
         &Default::default(),
-    )?;
+    )
+    .await?;
     let device = IronOxide::generate_new_device(
         &gen_jwt(Some(user.id())).0,
         USER_PASSWORD,
         &Default::default(),
-    )?;
-    let sdk = ironoxide::initialize(&device)?;
-    run_async(sdk.group_create(&GroupCreateOpts::new(
+    )
+    .await?;
+    let sdk = ironoxide::initialize(&device).await?;
+    sdk.group_create(&GroupCreateOpts::new(
         None,
         None,
         true,
@@ -69,8 +73,9 @@ fn group_init_and_rotation_check() -> Result<(), IronOxideErr> {
         vec![],
         vec![],
         true,
-    )))?;
-    let init_and_rotation_check = ironoxide::initialize_check_rotation(&device)?;
+    ))
+    .await?;
+    let init_and_rotation_check = ironoxide::initialize_check_rotation(&device).await?;
     match init_and_rotation_check {
         InitAndRotationCheck::RotationNeeded(_, rotations_needed) => {
             assert!(rotations_needed.group_rotation_needed().is_some());
@@ -81,71 +86,81 @@ fn group_init_and_rotation_check() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
-#[test]
-fn group_rotate_private_key() -> Result<(), IronOxideErr> {
-    let creator_sdk = initialize_sdk()?;
-    let (member, member_sdk) = init_sdk_get_user();
+#[tokio::test]
+async fn group_rotate_private_key() -> Result<(), IronOxideErr> {
+    let creator_sdk = initialize_sdk().await?;
+    let (member, member_sdk) = init_sdk_get_user().await;
 
     // making non-default group so I can specify needs_rotation of true
-    let group_create = run_async(creator_sdk.group_create(&GroupCreateOpts::new(
-        None,
-        None,
-        true,
-        true,
-        None,
-        vec![],
-        vec![],
-        true,
-    )))?;
+    let group_create = creator_sdk
+        .group_create(&GroupCreateOpts::new(
+            None,
+            None,
+            true,
+            true,
+            None,
+            vec![],
+            vec![],
+            true,
+        ))
+        .await?;
     assert_eq!(group_create.needs_rotation(), Some(true));
 
     let bytes = vec![42u8, 43u8];
 
-    let encrypt_result = run_async(creator_sdk.document_encrypt(
-        &bytes,
-        &DocumentEncryptOpts::with_explicit_grants(
-            None,
-            None,
-            false,
-            vec![group_create.id().into()],
-        ),
-    ))?;
+    let encrypt_result = creator_sdk
+        .document_encrypt(
+            &bytes,
+            &DocumentEncryptOpts::with_explicit_grants(
+                None,
+                None,
+                false,
+                vec![group_create.id().into()],
+            ),
+        )
+        .await?;
     let encrypted_data = encrypt_result.encrypted_data();
 
-    let group_rotate = run_async(creator_sdk.group_rotate_private_key(group_create.id()))?;
+    let group_rotate = creator_sdk
+        .group_rotate_private_key(group_create.id())
+        .await?;
     assert_eq!(group_rotate.needs_rotation(), false);
 
-    run_async(creator_sdk.group_add_members(group_create.id(), &vec![member]))?;
+    creator_sdk
+        .group_add_members(group_create.id(), &vec![member])
+        .await?;
 
-    let creator_decrypt_result = run_async(creator_sdk.document_decrypt(encrypted_data))?;
+    let creator_decrypt_result = creator_sdk.document_decrypt(encrypted_data).await?;
     let creator_decrypted_data = creator_decrypt_result.decrypted_data().to_vec();
     assert_eq!(creator_decrypted_data, bytes);
 
-    let member_decrypt_result = run_async(member_sdk.document_decrypt(encrypted_data))?;
+    let member_decrypt_result = member_sdk.document_decrypt(encrypted_data).await?;
     let member_decrypted_data = member_decrypt_result.decrypted_data().to_vec();
     assert_eq!(member_decrypted_data, bytes);
 
     Ok(())
 }
 
-#[test]
-fn group_rotate_private_key_non_admin() -> Result<(), IronOxideErr> {
-    let creator_sdk = initialize_sdk()?;
-    let member_sdk = initialize_sdk()?;
+#[tokio::test]
+async fn group_rotate_private_key_non_admin() -> Result<(), IronOxideErr> {
+    let creator_sdk = initialize_sdk().await?;
+    let member_sdk = initialize_sdk().await?;
 
     // making non-default group so I can specify needs_rotation of true
-    let group_create = run_async(creator_sdk.group_create(&GroupCreateOpts::new(
-        None,
-        None,
-        true,
-        true,
-        None,
-        vec![],
-        vec![],
-        true,
-    )))?;
+    let group_create = creator_sdk
+        .group_create(&GroupCreateOpts::new(
+            None,
+            None,
+            true,
+            true,
+            None,
+            vec![],
+            vec![],
+            true,
+        ))
+        .await?;
 
-    let group_rotate = run_async(member_sdk.group_rotate_private_key(group_create.id()));
+    let group_rotate = member_sdk.group_rotate_private_key(group_create.id()).await;
     assert_that!(
         &group_rotate.unwrap_err(),
         is_variant!(IronOxideErr::NotGroupAdmin)
@@ -154,59 +169,64 @@ fn group_rotate_private_key_non_admin() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
-#[test]
-fn rotate_all() -> Result<(), IronOxideErr> {
+#[tokio::test]
+async fn rotate_all() -> Result<(), IronOxideErr> {
     use ironoxide::{user::UserCreateOpts, InitAndRotationCheck};
     let account_id: UserId = create_id_all_classes("").try_into()?;
     let jwt = gen_jwt(Some(account_id.id())).0;
-    IronOxide::user_create(&jwt, USER_PASSWORD, &UserCreateOpts::new(true))?;
+    IronOxide::user_create(&jwt, USER_PASSWORD, &UserCreateOpts::new(true)).await?;
     let device = IronOxide::generate_new_device(
         &gen_jwt(Some(account_id.id())).0,
         USER_PASSWORD,
         &Default::default(),
-    )?;
-    let creator_sdk = ironoxide::initialize(&device)?;
+    )
+    .await?;
+    let creator_sdk = ironoxide::initialize(&device).await?;
     // making non-default groups so I can specify needs_rotation of true
-    let group_create1 = creator_sdk.group_create(&GroupCreateOpts::new(
-        None,
-        None,
-        true,
-        true,
-        None,
-        vec![],
-        vec![],
-        true,
-    ))?;
+    let group_create1 = creator_sdk
+        .group_create(&GroupCreateOpts::new(
+            None,
+            None,
+            true,
+            true,
+            None,
+            vec![],
+            vec![],
+            true,
+        ))
+        .await?;
     assert_eq!(group_create1.needs_rotation(), Some(true));
-    let group_create2 = creator_sdk.group_create(&GroupCreateOpts::new(
-        None,
-        None,
-        true,
-        true,
-        None,
-        vec![],
-        vec![],
-        true,
-    ))?;
+    let group_create2 = creator_sdk
+        .group_create(&GroupCreateOpts::new(
+            None,
+            None,
+            true,
+            true,
+            None,
+            vec![],
+            vec![],
+            true,
+        ))
+        .await?;
     assert_eq!(group_create2.needs_rotation(), Some(true));
 
-    let init_and_rotation_check = ironoxide::initialize_check_rotation(&device)?;
+    let init_and_rotation_check = ironoxide::initialize_check_rotation(&device).await?;
     let (user_result, group_result) = match init_and_rotation_check {
         InitAndRotationCheck::NoRotationNeeded(_) => {
             panic!("both user and groups should need rotation!");
         }
-        InitAndRotationCheck::RotationNeeded(io, rot) => rot.rotate_all(&io, USER_PASSWORD)?,
+        InitAndRotationCheck::RotationNeeded(io, rot) => rot.rotate_all(&io, USER_PASSWORD).await?,
     };
     assert!(user_result.is_some());
     assert!(group_result.is_some());
 
     assert_eq!(group_result.unwrap().len(), 2);
 
-    let user_result = IronOxide::user_verify(&jwt)?;
+    let user_result = IronOxide::user_verify(&jwt).await?;
     assert!(!user_result.unwrap().needs_rotation());
 
-    let group1_result = creator_sdk.group_get_metadata(group_create1.id())?;
-    let group2_result = creator_sdk.group_get_metadata(group_create2.id())?;
+    let group1_result = creator_sdk.group_get_metadata(group_create1.id()).await?;
+    let group2_result = creator_sdk.group_get_metadata(group_create2.id()).await?;
 
     assert!(!group1_result.needs_rotation().unwrap());
     assert!(!group2_result.needs_rotation().unwrap());
@@ -214,21 +234,21 @@ fn rotate_all() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
-#[test]
-fn group_get_metadata() -> Result<(), IronOxideErr> {
-    let admin_sdk = initialize_sdk()?;
-    let member_sdk = initialize_sdk()?;
-    let nonmember_sdk = initialize_sdk()?;
+#[tokio::test]
+async fn group_get_metadata() -> Result<(), IronOxideErr> {
+    let admin_sdk = initialize_sdk().await?;
+    let member_sdk = initialize_sdk().await?;
+    let nonmember_sdk = initialize_sdk().await?;
 
     let member_id = member_sdk.device().account_id().clone();
-    let group = admin_sdk.group_create(&Default::default());
+    let group = admin_sdk.group_create(&Default::default()).await;
     let group_id = &group?.id().clone();
 
-    admin_sdk.group_add_members(&group_id, &[member_id])?;
+    admin_sdk.group_add_members(&group_id, &[member_id]).await?;
 
-    let admin_group_get = admin_sdk.group_get_metadata(group_id)?;
-    let member_group_get = member_sdk.group_get_metadata(group_id)?;
-    let nonmember_group_get = nonmember_sdk.group_get_metadata(group_id)?;
+    let admin_group_get = admin_sdk.group_get_metadata(group_id).await?;
+    let member_group_get = member_sdk.group_get_metadata(group_id).await?;
+    let nonmember_group_get = nonmember_sdk.group_get_metadata(group_id).await?;
 
     assert_eq!(admin_group_get.needs_rotation(), Some(false));
     assert_eq!(member_group_get.needs_rotation(), None);
@@ -246,108 +266,121 @@ fn group_get_metadata() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
-#[test]
-fn group_delete() -> Result<(), IronOxideErr> {
-    let sdk = initialize_sdk()?;
+#[tokio::test]
+async fn group_delete() -> Result<(), IronOxideErr> {
+    let sdk = initialize_sdk().await?;
 
-    let group_result = sdk.group_create(&GroupCreateOpts::new(
-        Some(create_id_all_classes("").try_into()?),
-        None,
-        true,
-        true,
-        None,
-        vec![],
-        vec![],
-        false,
-    ))?;
+    let group_result = sdk
+        .group_create(&GroupCreateOpts::new(
+            Some(create_id_all_classes("").try_into()?),
+            None,
+            true,
+            true,
+            None,
+            vec![],
+            vec![],
+            false,
+        ))
+        .await?;
 
     let group_id = group_result.id().clone();
 
-    let group_delete_result = sdk.group_delete(&group_id)?;
+    let group_delete_result = sdk.group_delete(&group_id).await?;
     assert_eq!(group_id, group_delete_result.clone());
     Ok(())
 }
 
-#[test]
-fn group_update_name() -> Result<(), IronOxideErr> {
-    let sdk = initialize_sdk()?;
+#[tokio::test]
+async fn group_update_name() -> Result<(), IronOxideErr> {
+    let sdk = initialize_sdk().await?;
 
-    let group_result = sdk.group_create(&GroupCreateOpts::new(
-        Some(create_id_all_classes("").try_into()?),
-        Some("first name".try_into()?),
-        true,
-        false,
-        None,
-        vec![],
-        vec![],
-        false,
-    ))?;
+    let group_result = sdk
+        .group_create(&GroupCreateOpts::new(
+            Some(create_id_all_classes("").try_into()?),
+            Some("first name".try_into()?),
+            true,
+            false,
+            None,
+            vec![],
+            vec![],
+            false,
+        ))
+        .await?;
 
     assert_eq!(
         group_result.name().unwrap().name(),
         &"first name".to_string()
     );
 
-    let updated_group = sdk.group_update_name(group_result.id(), Some(&"new name".try_into()?))?;
+    let updated_group = sdk
+        .group_update_name(group_result.id(), Some(&"new name".try_into()?))
+        .await?;
 
     assert_eq!(
         updated_group.name(),
         Some(&"new name".try_into().expect("this name is valid"))
     );
 
-    let cleared_name = sdk.group_update_name(updated_group.id(), None)?;
+    let cleared_name = sdk.group_update_name(updated_group.id(), None).await?;
 
     assert!(cleared_name.name().is_none());
     Ok(())
 }
 
-#[test]
-fn group_add_member() -> Result<(), IronOxideErr> {
-    let (account_id, sdk) = init_sdk_get_user();
+#[tokio::test]
+async fn group_add_member() -> Result<(), IronOxideErr> {
+    let (account_id, sdk) = init_sdk_get_user().await;
 
-    let group_result = sdk.group_create(&GroupCreateOpts::new(
-        Some(create_id_all_classes("").try_into()?),
-        None,
-        true,
-        false,
-        None,
-        vec![],
-        vec![],
-        false,
-    ))?;
+    let group_result = sdk
+        .group_create(&GroupCreateOpts::new(
+            Some(create_id_all_classes("").try_into()?),
+            None,
+            true,
+            false,
+            None,
+            vec![],
+            vec![],
+            false,
+        ))
+        .await?;
 
     let group_id = group_result.id().clone();
     //Call to add ourselves to the group, since we didn't add on create, this should succeed.
-    let add_member_res = sdk.group_add_members(&group_id, &[account_id.clone()])?;
+    let add_member_res = sdk
+        .group_add_members(&group_id, &[account_id.clone()])
+        .await?;
     assert_eq!(add_member_res.succeeded().len(), 1);
     assert_eq!(add_member_res.failed().len(), 0);
     //The 2nd should have a failure for an account id that doesn't exist and for the one that was already added
     let fake_account_id = Uuid::new_v4().to_string().try_into()?;
-    let add_member_res_second =
-        sdk.group_add_members(&group_id, &[account_id.clone(), fake_account_id])?;
+    let add_member_res_second = sdk
+        .group_add_members(&group_id, &[account_id.clone(), fake_account_id])
+        .await?;
     assert_eq!(add_member_res_second.succeeded().len(), 0);
     assert_eq!(add_member_res_second.failed().len(), 2);
     Ok(())
 }
 
-#[test]
-fn group_add_member_on_create() -> Result<(), IronOxideErr> {
+#[tokio::test]
+async fn group_add_member_on_create() -> Result<(), IronOxideErr> {
     use std::{collections::HashSet, iter::FromIterator};
-    let (account_id, sdk) = init_sdk_get_user();
-    let second_account_id = initialize_sdk()?.device().account_id().clone();
+    let (account_id, sdk) = init_sdk_get_user().await;
+    let second_account_id = initialize_sdk().await?.device().account_id().clone();
 
     // Even though `add_as_member` is false, the UserId is in the `members` list,
     // so the caller becomes a member regardless
-    let group_result = sdk.group_create(&GroupCreateOpts::new(
-        Some(create_id_all_classes("").try_into()?),
-        None,
-        true,
-        false,
-        None,
-        vec![],
-        vec![account_id.clone(), second_account_id.clone()],
-        false,
-    ))?;
+    let group_result = sdk
+        .group_create(&GroupCreateOpts::new(
+            Some(create_id_all_classes("").try_into()?),
+            None,
+            true,
+            false,
+            None,
+            vec![],
+            vec![account_id.clone(), second_account_id.clone()],
+            false,
+        ))
+        .await?;
 
     assert_eq!(group_result.owner(), sdk.device().account_id());
 
@@ -360,23 +393,25 @@ fn group_add_member_on_create() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
-#[test]
-fn group_add_specific_owner() -> Result<(), IronOxideErr> {
-    let sdk = initialize_sdk()?;
-    let second_account_id = initialize_sdk()?.device().account_id().clone();
+#[tokio::test]
+async fn group_add_specific_owner() -> Result<(), IronOxideErr> {
+    let sdk = initialize_sdk().await?;
+    let second_account_id = initialize_sdk().await?.device().account_id().clone();
 
     // because the owner is specified, GroupCreateOpts.standardize() adds them
     // to the admins list
-    let group_result = sdk.group_create(&GroupCreateOpts::new(
-        Some(create_id_all_classes("").try_into()?),
-        None,
-        false,
-        false,
-        Some(second_account_id.clone()),
-        vec![],
-        vec![second_account_id.clone()],
-        false,
-    ))?;
+    let group_result = sdk
+        .group_create(&GroupCreateOpts::new(
+            Some(create_id_all_classes("").try_into()?),
+            None,
+            false,
+            false,
+            Some(second_account_id.clone()),
+            vec![],
+            vec![second_account_id.clone()],
+            false,
+        ))
+        .await?;
 
     assert_eq!(group_result.owner(), &second_account_id);
     assert_eq!(group_result.members(), &vec![second_account_id.clone()]);
@@ -385,22 +420,24 @@ fn group_add_specific_owner() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
-#[test]
-fn group_add_admin_on_create() -> Result<(), IronOxideErr> {
+#[tokio::test]
+async fn group_add_admin_on_create() -> Result<(), IronOxideErr> {
     use std::{collections::HashSet, iter::FromIterator};
-    let (account_id, sdk) = init_sdk_get_user();
-    let (second_account_id, _) = init_sdk_get_user();
+    let (account_id, sdk) = init_sdk_get_user().await;
+    let (second_account_id, _) = init_sdk_get_user().await;
 
-    let group_result = sdk.group_create(&GroupCreateOpts::new(
-        Some(create_id_all_classes("").try_into()?),
-        None,
-        true,
-        false,
-        Some(account_id.clone()),
-        vec![second_account_id.clone()],
-        vec![],
-        false,
-    ))?;
+    let group_result = sdk
+        .group_create(&GroupCreateOpts::new(
+            Some(create_id_all_classes("").try_into()?),
+            None,
+            true,
+            false,
+            Some(account_id.clone()),
+            vec![second_account_id.clone()],
+            vec![],
+            false,
+        ))
+        .await?;
 
     assert_eq!(group_result.owner(), &account_id);
 
@@ -413,20 +450,22 @@ fn group_add_admin_on_create() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
-#[test]
-fn group_add_admin_invalid_ids() -> Result<(), IronOxideErr> {
-    let sdk = initialize_sdk()?;
+#[tokio::test]
+async fn group_add_admin_invalid_ids() -> Result<(), IronOxideErr> {
+    let sdk = initialize_sdk().await?;
 
-    let group_result = sdk.group_create(&GroupCreateOpts::new(
-        Some(create_id_all_classes("").try_into()?),
-        None,
-        true,
-        false,
-        Some(UserId::unsafe_from_string("likeafox".to_string())),
-        vec![UserId::unsafe_from_string("whatsthenextwhat".to_string())],
-        vec![UserId::unsafe_from_string("aretheseuserids".to_string())],
-        false,
-    ));
+    let group_result = sdk
+        .group_create(&GroupCreateOpts::new(
+            Some(create_id_all_classes("").try_into()?),
+            None,
+            true,
+            false,
+            Some(UserId::unsafe_from_string("likeafox".to_string())),
+            vec![UserId::unsafe_from_string("whatsthenextwhat".to_string())],
+            vec![UserId::unsafe_from_string("aretheseuserids".to_string())],
+            false,
+        ))
+        .await;
 
     assert_that!(
         &group_result.unwrap_err(),
@@ -436,20 +475,22 @@ fn group_add_admin_invalid_ids() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
-#[test]
-fn group_owner_not_an_admin() -> Result<(), IronOxideErr> {
-    let sdk = initialize_sdk()?;
+#[tokio::test]
+async fn group_owner_not_an_admin() -> Result<(), IronOxideErr> {
+    let sdk = initialize_sdk().await?;
 
-    let group_result = sdk.group_create(&GroupCreateOpts::new(
-        Some(create_id_all_classes("").try_into()?),
-        None,
-        false,
-        false,
-        None,
-        vec![UserId::unsafe_from_string("antelope".to_string())],
-        vec![],
-        false,
-    ));
+    let group_result = sdk
+        .group_create(&GroupCreateOpts::new(
+            Some(create_id_all_classes("").try_into()?),
+            None,
+            false,
+            false,
+            None,
+            vec![UserId::unsafe_from_string("antelope".to_string())],
+            vec![],
+            false,
+        ))
+        .await;
 
     assert_that!(
         &group_result.unwrap_err(),
@@ -459,40 +500,43 @@ fn group_owner_not_an_admin() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
-#[test]
-fn group_list() -> Result<(), IronOxideErr> {
-    let sdk = initialize_sdk()?;
+#[tokio::test]
+async fn group_list() -> Result<(), IronOxideErr> {
+    let sdk = initialize_sdk().await?;
 
     //create two groups
-    sdk.group_create(&Default::default())?;
-    sdk.group_create(&Default::default())?;
+    sdk.group_create(&Default::default()).await?;
+    sdk.group_create(&Default::default()).await?;
 
-    let list_result = sdk.group_list()?;
+    let list_result = sdk.group_list().await?;
     assert_eq!(2, list_result.result().len());
     Ok(())
 }
 
-#[test]
-fn group_remove_member() -> Result<(), IronOxideErr> {
-    let sdk = initialize_sdk()?;
+#[tokio::test]
+async fn group_remove_member() -> Result<(), IronOxideErr> {
+    let sdk = initialize_sdk().await?;
     let account_id = sdk.device().account_id().clone();
 
-    let group_result = sdk.group_create(&GroupCreateOpts::new(
-        Some(create_id_all_classes("").try_into()?),
-        None,
-        true,
-        true,
-        None,
-        vec![],
-        vec![],
-        false,
-    ))?;
+    let group_result = sdk
+        .group_create(&GroupCreateOpts::new(
+            Some(create_id_all_classes("").try_into()?),
+            None,
+            true,
+            true,
+            None,
+            vec![],
+            vec![],
+            false,
+        ))
+        .await?;
     let group_id = group_result.id().clone();
 
     //Remove ourselves and another missing user from the group. Should result in one success and one failure
     let fake_account_id: UserId = Uuid::new_v4().to_string().try_into()?;
-    let remove_members_res =
-        sdk.group_remove_members(&group_id, &[account_id.clone(), fake_account_id.clone()])?;
+    let remove_members_res = sdk
+        .group_remove_members(&group_id, &[account_id.clone(), fake_account_id.clone()])
+        .await?;
 
     assert_eq!(remove_members_res.succeeded().len(), 1);
     assert_eq!(&remove_members_res.succeeded()[0], &account_id);
@@ -501,28 +545,31 @@ fn group_remove_member() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
-#[test]
-fn group_add_admin() -> Result<(), IronOxideErr> {
-    let sdk = initialize_sdk()?;
+#[tokio::test]
+async fn group_add_admin() -> Result<(), IronOxideErr> {
+    let sdk = initialize_sdk().await?;
 
     let account_id = sdk.device().account_id().clone();
-    let second_account_id = initialize_sdk()?.device().account_id().clone();
+    let second_account_id = initialize_sdk().await?.device().account_id().clone();
 
-    let group_result = sdk.group_create(&GroupCreateOpts::new(
-        Some(create_id_all_classes("").try_into()?),
-        None,
-        true,
-        false,
-        None,
-        vec![],
-        vec![],
-        false,
-    ))?;
+    let group_result = sdk
+        .group_create(&GroupCreateOpts::new(
+            Some(create_id_all_classes("").try_into()?),
+            None,
+            true,
+            false,
+            None,
+            vec![],
+            vec![],
+            false,
+        ))
+        .await?;
 
     let group_id = group_result.id().clone();
     //Call to add ourselves and a second id as admins. Adding ourselves should fail and the other should succeed.
-    let add_member_res =
-        sdk.group_add_admins(&group_id, &[account_id.clone(), second_account_id.clone()])?;
+    let add_member_res = sdk
+        .group_add_admins(&group_id, &[account_id.clone(), second_account_id.clone()])
+        .await?;
 
     assert_eq!(add_member_res.succeeded().len(), 1);
     assert_eq!(add_member_res.succeeded()[0], second_account_id);
@@ -531,44 +578,50 @@ fn group_add_admin() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
-#[test]
-fn group_remove_admin() -> Result<(), IronOxideErr> {
-    let sdk = initialize_sdk()?;
+#[tokio::test]
+async fn group_remove_admin() -> Result<(), IronOxideErr> {
+    let sdk = initialize_sdk().await?;
 
-    let second_account_id = create_second_user().account_id().clone();
+    let second_account_id = create_second_user().await.account_id().clone();
 
-    let group_result = sdk.group_create(&GroupCreateOpts::default())?;
+    let group_result = sdk.group_create(&GroupCreateOpts::default()).await?;
 
     let group_id = group_result.id().clone();
     //Call to add the second id as an admin.
-    let add_member_res = sdk.group_add_admins(&group_id, &[second_account_id.clone()])?;
+    let add_member_res = sdk
+        .group_add_admins(&group_id, &[second_account_id.clone()])
+        .await?;
     assert_eq!(add_member_res.succeeded().len(), 1);
     //Then remove them, which should succeed.
-    let remove_member_res = sdk.group_remove_admins(&group_id, &[second_account_id.clone()])?;
+    let remove_member_res = sdk
+        .group_remove_admins(&group_id, &[second_account_id.clone()])
+        .await?;
     assert_eq!(remove_member_res.succeeded().len(), 1);
     assert_eq!(remove_member_res.succeeded()[0], second_account_id);
     assert_eq!(remove_member_res.failed().len(), 0);
     Ok(())
 }
 
-#[test]
-fn group_get_not_url_safe_id() -> Result<(), IronOxideErr> {
-    let sdk = initialize_sdk()?;
+#[tokio::test]
+async fn group_get_not_url_safe_id() -> Result<(), IronOxideErr> {
+    let sdk = initialize_sdk().await?;
 
     let not_url_safe_id: GroupId =
         format!("{}{}", Uuid::new_v4(), "'=#.other|/$non@;safe'-:;id_").try_into()?;
-    let group_create_result = sdk.group_create(&GroupCreateOpts::new(
-        Some(not_url_safe_id.clone()),
-        None,
-        true,
-        false,
-        None,
-        vec![],
-        vec![],
-        false,
-    ))?;
+    let group_create_result = sdk
+        .group_create(&GroupCreateOpts::new(
+            Some(not_url_safe_id.clone()),
+            None,
+            true,
+            false,
+            None,
+            vec![],
+            vec![],
+            false,
+        ))
+        .await?;
 
-    let get_result = sdk.group_get_metadata(&not_url_safe_id)?;
+    let get_result = sdk.group_get_metadata(&not_url_safe_id).await?;
     assert_eq!(&not_url_safe_id, group_create_result.id());
     assert_eq!(&not_url_safe_id, get_result.id());
     Ok(())

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -12,23 +12,24 @@ use uuid::Uuid;
 #[macro_use]
 extern crate serde_json;
 
-#[test]
-fn user_verify_non_existing_user() -> Result<(), IronOxideErr> {
-    let option_result = IronOxide::user_verify(&gen_jwt(None).0)?;
+#[tokio::test]
+async fn user_verify_non_existing_user() -> Result<(), IronOxideErr> {
+    let option_result = IronOxide::user_verify(&gen_jwt(None).0).await?;
     assert_eq!(true, option_result.is_none());
     Ok(())
 }
 
-#[test]
-fn user_verify_existing_user() -> Result<(), IronOxideErr> {
+#[tokio::test]
+async fn user_verify_existing_user() -> Result<(), IronOxideErr> {
     let account_id: UserId = create_id_all_classes("").try_into()?;
     IronOxide::user_create(
         &gen_jwt(Some(account_id.id())).0,
         "foo",
         &Default::default(),
-    )?;
+    )
+    .await?;
 
-    let result = IronOxide::user_verify(&gen_jwt(Some(account_id.id())).0)?;
+    let result = IronOxide::user_verify(&gen_jwt(Some(account_id.id())).0).await?;
     assert_eq!(true, result.is_some());
     let verify_resp = result.unwrap();
 
@@ -36,36 +37,39 @@ fn user_verify_existing_user() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
-#[test]
-fn user_verify_after_create_with_needs_rotation() -> Result<(), IronOxideErr> {
+#[tokio::test]
+async fn user_verify_after_create_with_needs_rotation() -> Result<(), IronOxideErr> {
     let account_id: UserId = Uuid::new_v4().to_string().try_into()?;
     IronOxide::user_create(
         &gen_jwt(Some(account_id.id())).0,
         "foo",
         &UserCreateOpts::new(true),
-    )?;
+    )
+    .await?;
 
-    let result = IronOxide::user_verify(&gen_jwt(Some(account_id.id())).0)?;
+    let result = IronOxide::user_verify(&gen_jwt(Some(account_id.id())).0).await?;
     assert!(result.is_some());
     let verify_resp = result.unwrap();
     assert!(verify_resp.needs_rotation());
     Ok(())
 }
-#[test]
-fn user_create_good_with_devices() -> Result<(), IronOxideErr> {
+#[tokio::test]
+async fn user_create_good_with_devices() -> Result<(), IronOxideErr> {
     let account_id: UserId = Uuid::new_v4().to_string().try_into()?;
     IronOxide::user_create(
         &gen_jwt(Some(account_id.id())).0,
         "foo",
         &Default::default(),
-    )?;
+    )
+    .await?;
     let device = IronOxide::generate_new_device(
         &gen_jwt(Some(account_id.id())).0,
         "foo",
         &DeviceCreateOpts::new(Some("myDevice".try_into()?)),
-    )?;
-    let sdk = ironoxide::initialize(&device)?;
-    let device_list = sdk.user_list_devices()?;
+    )
+    .await?;
+    let sdk = ironoxide::initialize(&device).await?;
+    let device_list = sdk.user_list_devices().await?;
 
     assert_eq!(1, device_list.result().len());
     assert_eq!(
@@ -75,14 +79,14 @@ fn user_create_good_with_devices() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
-#[test]
-fn user_private_key_rotation() -> Result<(), IronOxideErr> {
-    let io = initialize_sdk()?;
+#[tokio::test]
+async fn user_private_key_rotation() -> Result<(), IronOxideErr> {
+    let io = initialize_sdk().await?;
 
-    let result1 = io.user_rotate_private_key(common::USER_PASSWORD)?;
+    let result1 = io.user_rotate_private_key(common::USER_PASSWORD).await?;
     assert_eq!(result1.needs_rotation(), false);
 
-    let result2 = io.user_rotate_private_key(common::USER_PASSWORD)?;
+    let result2 = io.user_rotate_private_key(common::USER_PASSWORD).await?;
     assert_ne!(
         &result1.user_master_private_key(),
         &result2.user_master_private_key()
@@ -91,16 +95,16 @@ fn user_private_key_rotation() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
-#[test]
-fn sdk_init_with_private_key_rotation() -> Result<(), IronOxideErr> {
+#[tokio::test]
+async fn sdk_init_with_private_key_rotation() -> Result<(), IronOxideErr> {
     use ironoxide::InitAndRotationCheck;
 
-    let (user_id, init_result) = common::init_sdk_get_init_result(true);
+    let (user_id, init_result) = common::init_sdk_get_init_result(true).await;
     let _: IronOxide = match init_result {
         InitAndRotationCheck::NoRotationNeeded(_ironoxide) => panic!("user should need rotation"),
         InitAndRotationCheck::RotationNeeded(io, rotation_check) => {
             assert_eq!(rotation_check.user_rotation_needed(), Some(&user_id));
-            let rotation_result = io.user_rotate_private_key(common::USER_PASSWORD)?;
+            let rotation_result = io.user_rotate_private_key(common::USER_PASSWORD).await?;
             assert_eq!(rotation_result.needs_rotation(), false);
             io
         }
@@ -108,31 +112,34 @@ fn sdk_init_with_private_key_rotation() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
-#[test]
-fn user_add_device_after_rotation() -> Result<(), IronOxideErr> {
+#[tokio::test]
+async fn user_add_device_after_rotation() -> Result<(), IronOxideErr> {
     //create a user
-    let (user, sdk) = common::init_sdk_get_user();
+    let (user, sdk) = common::init_sdk_get_user().await;
     let bytes = vec![42u8, 43u8];
 
-    let encrypt_result = sdk.document_encrypt(
-        &bytes,
-        &DocumentEncryptOpts::with_explicit_grants(None, None, true, vec![]),
-    )?;
+    let encrypt_result = sdk
+        .document_encrypt(
+            &bytes,
+            &DocumentEncryptOpts::with_explicit_grants(None, None, true, vec![]),
+        )
+        .await?;
     let encrypted_data = encrypt_result.encrypted_data();
 
     //rotate the private key
-    let _rotation_result = sdk.user_rotate_private_key(common::USER_PASSWORD)?;
+    let _rotation_result = sdk.user_rotate_private_key(common::USER_PASSWORD).await?;
 
     //add a new device
     let new_device = IronOxide::generate_new_device(
         &common::gen_jwt(Some(user.id())).0,
         common::USER_PASSWORD,
         &Default::default(),
-    )?;
+    )
+    .await?;
 
     //reinitialize the sdk with the new device and decrypt some data
-    let new_sdk = ironoxide::initialize(&new_device)?;
-    let decrypt_result = new_sdk.document_decrypt(&encrypted_data)?;
+    let new_sdk = ironoxide::initialize(&new_device).await?;
+    let decrypt_result = new_sdk.document_decrypt(&encrypted_data).await?;
     let decrypted_data = decrypt_result.decrypted_data();
 
     assert_eq!(bytes, decrypted_data.to_vec());
@@ -140,14 +147,15 @@ fn user_add_device_after_rotation() -> Result<(), IronOxideErr> {
     Ok(())
 }
 
-#[test]
-fn user_create_with_needs_rotation() -> Result<(), IronOxideErr> {
+#[tokio::test]
+async fn user_create_with_needs_rotation() -> Result<(), IronOxideErr> {
     let account_id: UserId = Uuid::new_v4().to_string().try_into()?;
     let result = IronOxide::user_create(
         &gen_jwt(Some(account_id.id())).0,
         common::USER_PASSWORD,
         &UserCreateOpts::new(true),
-    );
+    )
+    .await;
     assert!(result?.needs_rotation());
     Ok(())
 }


### PR DESCRIPTION
See #93 

We've decided that for now we are going to only provide an async API as this simplifies things given our internal API is async. If we need a sync API again in the future, it could be added in a separate name space, perhaps with a feature flag.

Obviously this is a huge breaking change, so we're merging this into a feature branch for now.

## TODO
* [x] changelog entry
* [ ] ~make sure this works on stable~ (do this prior to merging to master)