### PR TITLE
Add DeviceAddResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.17.0 (Unreleased)
 
+- [[#107](https://github.com/IronCoreLabs/ironoxide/pull/107)]
+  - Change `generate_new_device()` to return a `DeviceAddResult`
 - [[#101](https://github.com/IronCoreLabs/ironoxide/pull/101)]
   - Dependecy upgrades
 

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -372,28 +372,6 @@ pub struct DeviceAddResult {
 }
 
 impl DeviceAddResult {
-    fn new(
-        account_id: UserId,
-        segment_id: usize,
-        device_private_key: PrivateKey,
-        signing_private_key: DeviceSigningKeyPair,
-        device_id: DeviceId,
-        name: Option<DeviceName>,
-        created: DateTime<Utc>,
-        updated: DateTime<Utc>,
-    ) -> DeviceAddResult {
-        DeviceAddResult {
-            account_id,
-            segment_id,
-            device_private_key,
-            signing_private_key,
-            device_id,
-            name,
-            created,
-            updated,
-        }
-    }
-
     pub fn account_id(&self) -> &UserId {
         &self.account_id
     }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -356,7 +356,8 @@ impl From<DeviceAddResult> for DeviceContext {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+// Note: Equality is not provided to protect the security of the device private key.
+#[derive(Debug, Clone)]
 pub struct DeviceAddResult {
     /// The user's given id, which uniquely identifies them inside the segment.
     account_id: UserId,

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -251,7 +251,7 @@ pub mod auth_v2 {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RequestAuth {
-    ///The users given id, which uniquely identifies them inside the segment.
+    ///The user's given id, which uniquely identifies them inside the segment.
     account_id: UserId,
     ///The segment_id for the above user.
     segment_id: usize,
@@ -299,13 +299,13 @@ impl RequestAuth {
 pub struct DeviceContext {
     #[serde(flatten)]
     auth: RequestAuth,
-    ///The private key which was generated for a particular device for the user. Not the user's master private key.
+    /// The private key which was generated for a particular device for the user. Not the user's master private key.
     device_private_key: PrivateKey,
 }
 
 impl DeviceContext {
     /// Create a new DeviceContext to get an SDK instance for the provided context. Takes an account's UserID,
-    /// segment id, private device keys, and signing keys. An instance of this structure is returned directly
+    /// segment id, private device keys, and signing keys. An instance of this structure can be created
     /// from the `IronOxide.generate_new_device()` method.
     pub fn new(
         account_id: UserId,
@@ -358,16 +358,21 @@ impl From<DeviceAddResult> for DeviceContext {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeviceAddResult {
-    ///The user's given id, which uniquely identifies them inside the segment.
+    /// The user's given id, which uniquely identifies them inside the segment.
     account_id: UserId,
-    ///The segment_id for the above user.
+    /// The user's segment id
     segment_id: usize,
+    /// The private key which was generated for a particular device for the user. Not the user's master private key.
     device_private_key: PrivateKey,
-    ///The signing key which was generated for the device. “expanded private key” (both pub/priv)
+    /// The signing key which was generated for the device. “expanded private key” (both pub/priv)
     signing_private_key: DeviceSigningKeyPair,
+    /// The id of the device that was added
     device_id: DeviceId,
+    /// The name of the device that was added
     name: Option<DeviceName>,
+    /// The date and time that the device was created
     created: DateTime<Utc>,
+    /// The date and time that the device was last updated
     updated: DateTime<Utc>,
 }
 

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -5,7 +5,7 @@
 use crate::internal::{
     group_api::GroupId,
     rest::{Authorization, IronCoreRequest, SignatureUrlString},
-    user_api::UserId,
+    user_api::{DeviceId, DeviceName, UserId},
 };
 use chrono::{DateTime, Utc};
 use log::error;
@@ -342,6 +342,88 @@ impl DeviceContext {
 
     pub fn device_private_key(&self) -> &PrivateKey {
         &self.device_private_key
+    }
+}
+
+impl From<DeviceAddResult> for DeviceContext {
+    fn from(dar: DeviceAddResult) -> Self {
+        DeviceContext::new(
+            dar.account_id().to_owned(),
+            dar.segment_id(),
+            dar.device_private_key().to_owned(),
+            dar.signing_private_key().to_owned(),
+        )
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeviceAddResult {
+    ///The user's given id, which uniquely identifies them inside the segment.
+    account_id: UserId,
+    ///The segment_id for the above user.
+    segment_id: usize,
+    device_private_key: PrivateKey,
+    ///The signing key which was generated for the device. “expanded private key” (both pub/priv)
+    signing_private_key: DeviceSigningKeyPair,
+    device_id: DeviceId,
+    name: Option<DeviceName>,
+    created: DateTime<Utc>,
+    updated: DateTime<Utc>,
+}
+
+impl DeviceAddResult {
+    fn new(
+        account_id: UserId,
+        segment_id: usize,
+        device_private_key: PrivateKey,
+        signing_private_key: DeviceSigningKeyPair,
+        device_id: DeviceId,
+        name: Option<DeviceName>,
+        created: DateTime<Utc>,
+        updated: DateTime<Utc>,
+    ) -> DeviceAddResult {
+        DeviceAddResult {
+            account_id,
+            segment_id,
+            device_private_key,
+            signing_private_key,
+            device_id,
+            name,
+            created,
+            updated,
+        }
+    }
+
+    pub fn account_id(&self) -> &UserId {
+        &self.account_id
+    }
+
+    pub fn segment_id(&self) -> usize {
+        self.segment_id
+    }
+
+    pub fn signing_private_key(&self) -> &DeviceSigningKeyPair {
+        &self.signing_private_key
+    }
+
+    pub fn device_private_key(&self) -> &PrivateKey {
+        &self.device_private_key
+    }
+
+    pub fn device_id(&self) -> &DeviceId {
+        &self.device_id
+    }
+
+    pub fn name(&self) -> Option<&DeviceName> {
+        self.name.as_ref()
+    }
+
+    pub fn created(&self) -> &DateTime<Utc> {
+        &self.created
+    }
+
+    pub fn updated(&self) -> &DateTime<Utc> {
+        &self.updated
     }
 }
 

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -374,7 +374,7 @@ pub struct DeviceAddResult {
     /// The date and time that the device was created
     created: DateTime<Utc>,
     /// The date and time that the device was last updated
-    updated: DateTime<Utc>,
+    last_updated: DateTime<Utc>,
 }
 
 impl DeviceAddResult {
@@ -406,8 +406,8 @@ impl DeviceAddResult {
         &self.created
     }
 
-    pub fn updated(&self) -> &DateTime<Utc> {
-        &self.updated
+    pub fn last_updated(&self) -> &DateTime<Utc> {
+        &self.last_updated
     }
 }
 

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -306,7 +306,7 @@ pub struct DeviceContext {
 impl DeviceContext {
     /// Create a new DeviceContext to get an SDK instance for the provided context. Takes an account's UserID,
     /// segment id, private device keys, and signing keys. An instance of this structure can be created
-    /// from the `IronOxide.generate_new_device()` method.
+    /// from the result of the `IronOxide.generate_new_device()` method.
     pub fn new(
         account_id: UserId,
         segment_id: usize,
@@ -348,10 +348,10 @@ impl DeviceContext {
 impl From<DeviceAddResult> for DeviceContext {
     fn from(dar: DeviceAddResult) -> Self {
         DeviceContext::new(
-            dar.account_id().to_owned(),
-            dar.segment_id(),
-            dar.device_private_key().to_owned(),
-            dar.signing_private_key().to_owned(),
+            dar.account_id,
+            dar.segment_id,
+            dar.device_private_key,
+            dar.signing_private_key,
         )
     }
 }

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -372,7 +372,7 @@ pub async fn generate_device_key<CR: rand::CryptoRng + rand::RngCore>(
         device_id: device_add_response.device_id,
         name: device_add_response.name,
         created: device_add_response.created,
-        updated: device_add_response.updated,
+        last_updated: device_add_response.updated,
     })
 }
 

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     crypto::aes::{self, EncryptedMasterKey},
-    internal::{rest::IronCoreRequest, user_api::requests::device_add::DeviceAddResponse, *},
+    internal::{rest::IronCoreRequest, *},
 };
 use chrono::{DateTime, Utc};
 use itertools::{Either, Itertools};
@@ -342,7 +342,7 @@ pub async fn generate_device_key<CR: rand::CryptoRng + rand::RngCore>(
             "Device cannot be added to a user that doesn't exist".to_string(),
         ))?;
     // unpack the verified user and create a DeviceAdd
-    let (device_add, account_id, segment_id) = (
+    let (device_add, account_id) = (
         {
             let user_public_key: RecryptPublicKey =
                 PublicKey::try_from(user_master_public_key)?.into();
@@ -355,32 +355,25 @@ pub async fn generate_device_key<CR: rand::CryptoRng + rand::RngCore>(
                 KeyPair::new(user_public_key, RecryptPrivateKey::new(user_private_key));
 
             // generate info needed to add a device
-            let device_add = generate_device_add(recrypt, &jwt, &user_keypair, &signing_ts)?;
-            device_add
+            generate_device_add(recrypt, &jwt, &user_keypair, &signing_ts)?
         },
         account_id.try_into()?,
-        segment_id,
     );
 
     // call device_add
-    let DeviceAddResponse {
-        device_id,
-        name,
-        created,
-        updated,
-        ..
-    } = requests::device_add::user_device_add(&jwt, &device_add, &device_name, &request).await?;
+    let device_add_response =
+        requests::device_add::user_device_add(&jwt, &device_add, &device_name, &request).await?;
     // on successful response, assemble a DeviceContext for the caller
-    Ok(DeviceAddResult::new(
+    Ok(DeviceAddResult {
         account_id,
         segment_id,
-        device_add.device_keys.private_key,
-        device_add.signing_keys,
-        device_id,
-        name,
-        created,
-        updated,
-    ))
+        device_private_key: device_add.device_keys.private_key,
+        signing_private_key: device_add.signing_keys,
+        device_id: device_add_response.device_id,
+        name: device_add_response.name,
+        created: device_add_response.created,
+        updated: device_add_response.updated,
+    })
 }
 
 pub async fn device_list(auth: &RequestAuth) -> Result<UserDeviceListResult, IronOxideErr> {

--- a/src/internal/user_api/requests.rs
+++ b/src/internal/user_api/requests.rs
@@ -14,7 +14,7 @@ use crate::{
         IronOxideErr, Jwt, RequestAuth, RequestErrorCode,
     },
 };
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use std::convert::TryFrom;
 
 use crate::internal::auth_v2::AuthV2Builder;
@@ -309,7 +309,6 @@ pub mod device_add {
         user_api::{requests::PublicKey, DeviceAdd, DeviceId},
         Jwt,
     };
-    use chrono::DateTime;
 
     use super::*;
 

--- a/src/internal/user_api/requests.rs
+++ b/src/internal/user_api/requests.rs
@@ -309,6 +309,7 @@ pub mod device_add {
         user_api::{requests::PublicKey, DeviceAdd, DeviceId},
         Jwt,
     };
+    use chrono::DateTime;
 
     use super::*;
 
@@ -335,6 +336,9 @@ pub mod device_add {
         #[serde(rename = "id")]
         pub device_id: DeviceId,
         pub device_public_key: PublicKey,
+        pub name: Option<DeviceName>,
+        pub created: DateTime<Utc>,
+        pub updated: DateTime<Utc>,
     }
 
     pub async fn user_device_add(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,8 @@ use crate::internal::{
     user_api::{UserId, UserResult, UserUpdatePrivateKeyResult},
 };
 pub use crate::internal::{
-    DeviceContext, DeviceSigningKeyPair, IronOxideErr, KeyPair, PrivateKey, PublicKey,
+    DeviceAddResult, DeviceContext, DeviceSigningKeyPair, IronOxideErr, KeyPair, PrivateKey,
+    PublicKey,
 };
 use itertools::EitherOrBoth;
 use rand::{

--- a/src/user.rs
+++ b/src/user.rs
@@ -7,7 +7,7 @@ use crate::{
         user_api::{self, DeviceId, DeviceName},
         DeviceAddResult, PublicKey, OUR_REQUEST,
     },
-    DeviceContext, IronOxide, Result,
+    IronOxide, Result,
 };
 use recrypt::api::Recrypt;
 use std::{collections::HashMap, convert::TryInto};

--- a/src/user.rs
+++ b/src/user.rs
@@ -5,7 +5,7 @@ pub use crate::internal::user_api::{
 use crate::{
     internal::{
         user_api::{self, DeviceId, DeviceName},
-        PublicKey, OUR_REQUEST,
+        DeviceAddResult, PublicKey, OUR_REQUEST,
     },
     DeviceContext, IronOxide, Result,
 };
@@ -96,7 +96,7 @@ pub trait UserOps {
         jwt: &str,
         password: &str,
         device_create_options: &DeviceCreateOpts,
-    ) -> Result<DeviceContext>;
+    ) -> Result<DeviceAddResult>;
 
     /// Delete a user device.
     ///
@@ -167,7 +167,7 @@ impl UserOps for IronOxide {
         jwt: &str,
         password: &str,
         device_create_options: &DeviceCreateOpts,
-    ) -> Result<DeviceContext> {
+    ) -> Result<DeviceAddResult> {
         let recrypt = Recrypt::new();
         let mut rt = Runtime::new().unwrap();
         let device_create_options = device_create_options.clone();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -119,7 +119,7 @@ pub fn initialize_sdk() -> Result<IronOxide, IronOxideErr> {
         USER_PASSWORD,
         &Default::default(),
     )?;
-    ironoxide::initialize(&device)
+    ironoxide::initialize(&device.into())
 }
 
 pub fn init_sdk_get_user() -> (UserId, IronOxide) {

--- a/tests/group_ops.rs
+++ b/tests/group_ops.rs
@@ -59,7 +59,7 @@ fn group_init_and_rotation_check() -> Result<(), IronOxideErr> {
         USER_PASSWORD,
         &Default::default(),
     )?;
-    let sdk = ironoxide::initialize(&device)?;
+    let sdk = ironoxide::initialize(&device.clone().into())?;
     sdk.group_create(&GroupCreateOpts::new(
         None,
         None,
@@ -70,7 +70,7 @@ fn group_init_and_rotation_check() -> Result<(), IronOxideErr> {
         vec![],
         true,
     ))?;
-    let init_and_rotation_check = ironoxide::initialize_check_rotation(&device)?;
+    let init_and_rotation_check = ironoxide::initialize_check_rotation(&device.into())?;
     match init_and_rotation_check {
         InitAndRotationCheck::RotationNeeded(_, rotations_needed) => {
             assert!(rotations_needed.group_rotation_needed().is_some());
@@ -165,7 +165,7 @@ fn rotate_all() -> Result<(), IronOxideErr> {
         USER_PASSWORD,
         &Default::default(),
     )?;
-    let creator_sdk = ironoxide::initialize(&device)?;
+    let creator_sdk = ironoxide::initialize(&device.clone().into())?;
     // making non-default groups so I can specify needs_rotation of true
     let group_create1 = creator_sdk.group_create(&GroupCreateOpts::new(
         None,
@@ -190,7 +190,7 @@ fn rotate_all() -> Result<(), IronOxideErr> {
     ))?;
     assert_eq!(group_create2.needs_rotation(), Some(true));
 
-    let init_and_rotation_check = ironoxide::initialize_check_rotation(&device)?;
+    let init_and_rotation_check = ironoxide::initialize_check_rotation(&device.into())?;
     let (user_result, group_result) = match init_and_rotation_check {
         InitAndRotationCheck::NoRotationNeeded(_) => {
             panic!("both user and groups should need rotation!");

--- a/tests/group_ops.rs
+++ b/tests/group_ops.rs
@@ -115,6 +115,9 @@ fn group_rotate_private_key() -> Result<(), IronOxideErr> {
     let group_rotate = creator_sdk.group_rotate_private_key(group_create.id())?;
     assert_eq!(group_rotate.needs_rotation(), false);
 
+    //let updated_group = creator_sdk.group_get_metadata(group_create.id())?;
+    //assert!(updated_group.last_updated() > updated_group.created());
+
     creator_sdk.group_add_members(group_create.id(), &vec![member])?;
 
     let creator_decrypt_result = creator_sdk.document_decrypt(encrypted_data)?;
@@ -294,6 +297,7 @@ fn group_update_name() -> Result<(), IronOxideErr> {
         updated_group.name(),
         Some(&"new name".try_into().expect("this name is valid"))
     );
+    assert!(updated_group.last_updated() > updated_group.created());
 
     let cleared_name = sdk.group_update_name(updated_group.id(), None)?;
 

--- a/tests/group_ops.rs
+++ b/tests/group_ops.rs
@@ -115,9 +115,6 @@ fn group_rotate_private_key() -> Result<(), IronOxideErr> {
     let group_rotate = creator_sdk.group_rotate_private_key(group_create.id())?;
     assert_eq!(group_rotate.needs_rotation(), false);
 
-    //let updated_group = creator_sdk.group_get_metadata(group_create.id())?;
-    //assert!(updated_group.last_updated() > updated_group.created());
-
     creator_sdk.group_add_members(group_create.id(), &vec![member])?;
 
     let creator_decrypt_result = creator_sdk.document_decrypt(encrypted_data)?;

--- a/tests/group_ops.rs
+++ b/tests/group_ops.rs
@@ -54,12 +54,13 @@ fn group_init_and_rotation_check() -> Result<(), IronOxideErr> {
         USER_PASSWORD,
         &Default::default(),
     )?;
-    let device = IronOxide::generate_new_device(
+    let device: DeviceContext = IronOxide::generate_new_device(
         &gen_jwt(Some(user.id())).0,
         USER_PASSWORD,
         &Default::default(),
-    )?;
-    let sdk = ironoxide::initialize(&device.clone().into())?;
+    )?
+    .into();
+    let sdk = ironoxide::initialize(&device)?;
     sdk.group_create(&GroupCreateOpts::new(
         None,
         None,
@@ -70,7 +71,7 @@ fn group_init_and_rotation_check() -> Result<(), IronOxideErr> {
         vec![],
         true,
     ))?;
-    let init_and_rotation_check = ironoxide::initialize_check_rotation(&device.into())?;
+    let init_and_rotation_check = ironoxide::initialize_check_rotation(&device)?;
     match init_and_rotation_check {
         InitAndRotationCheck::RotationNeeded(_, rotations_needed) => {
             assert!(rotations_needed.group_rotation_needed().is_some());
@@ -160,12 +161,13 @@ fn rotate_all() -> Result<(), IronOxideErr> {
     let account_id: UserId = create_id_all_classes("").try_into()?;
     let jwt = gen_jwt(Some(account_id.id())).0;
     IronOxide::user_create(&jwt, USER_PASSWORD, &UserCreateOpts::new(true))?;
-    let device = IronOxide::generate_new_device(
+    let device: DeviceContext = IronOxide::generate_new_device(
         &gen_jwt(Some(account_id.id())).0,
         USER_PASSWORD,
         &Default::default(),
-    )?;
-    let creator_sdk = ironoxide::initialize(&device.clone().into())?;
+    )?
+    .into();
+    let creator_sdk = ironoxide::initialize(&device)?;
     // making non-default groups so I can specify needs_rotation of true
     let group_create1 = creator_sdk.group_create(&GroupCreateOpts::new(
         None,
@@ -190,7 +192,7 @@ fn rotate_all() -> Result<(), IronOxideErr> {
     ))?;
     assert_eq!(group_create2.needs_rotation(), Some(true));
 
-    let init_and_rotation_check = ironoxide::initialize_check_rotation(&device.into())?;
+    let init_and_rotation_check = ironoxide::initialize_check_rotation(&device)?;
     let (user_result, group_result) = match init_and_rotation_check {
         InitAndRotationCheck::NoRotationNeeded(_) => {
             panic!("both user and groups should need rotation!");

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -130,6 +130,9 @@ fn user_add_device_after_rotation() -> Result<(), IronOxideErr> {
         &Default::default(),
     )?;
 
+    assert_eq!(new_device.created(), new_device.updated());
+    assert_eq!(new_device.name(), None);
+
     //reinitialize the sdk with the new device and decrypt some data
     let new_sdk = ironoxide::initialize(&new_device.into())?;
     let decrypt_result = new_sdk.document_decrypt(&encrypted_data)?;

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -59,12 +59,13 @@ fn user_create_good_with_devices() -> Result<(), IronOxideErr> {
         "foo",
         &Default::default(),
     )?;
-    let device = IronOxide::generate_new_device(
+    let device: DeviceContext = IronOxide::generate_new_device(
         &gen_jwt(Some(account_id.id())).0,
         "foo",
         &DeviceCreateOpts::new(Some("myDevice".try_into()?)),
-    )?;
-    let sdk = ironoxide::initialize(&device.into())?;
+    )?
+    .into();
+    let sdk = ironoxide::initialize(&device)?;
     let device_list = sdk.user_list_devices()?;
 
     assert_eq!(1, device_list.result().len());

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -64,7 +64,7 @@ fn user_create_good_with_devices() -> Result<(), IronOxideErr> {
         "foo",
         &DeviceCreateOpts::new(Some("myDevice".try_into()?)),
     )?;
-    let sdk = ironoxide::initialize(&device)?;
+    let sdk = ironoxide::initialize(&device.into())?;
     let device_list = sdk.user_list_devices()?;
 
     assert_eq!(1, device_list.result().len());
@@ -131,7 +131,7 @@ fn user_add_device_after_rotation() -> Result<(), IronOxideErr> {
     )?;
 
     //reinitialize the sdk with the new device and decrypt some data
-    let new_sdk = ironoxide::initialize(&new_device)?;
+    let new_sdk = ironoxide::initialize(&new_device.into())?;
     let decrypt_result = new_sdk.document_decrypt(&encrypted_data)?;
     let decrypted_data = decrypt_result.decrypted_data();
 

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -130,7 +130,7 @@ fn user_add_device_after_rotation() -> Result<(), IronOxideErr> {
         &Default::default(),
     )?;
 
-    assert_eq!(new_device.created(), new_device.updated());
+    assert_eq!(new_device.created(), new_device.last_updated());
     assert_eq!(new_device.name(), None);
 
     //reinitialize the sdk with the new device and decrypt some data


### PR DESCRIPTION
- Added `DeviceAddResult`, the new result of `generate_new_device()`
    - This contains the same fields as `DeviceContext` with the addition of `device_id`, `name`, `created`, and `updated`.
- Added `From<DeviceAddResult> for DeviceContext` to give a `DeviceContext` for functions like `initialize()`
- Updated `DeviceAddResponse` to include new fields