### PR TITLE
[#105] Fixes decryption of data with size 0 bytes and 1 byte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- [[#108](https://github.com/IronCoreLabs/ironoxide/pull/107)]
+  - Fixes bug to allow decryption of 0 and 1 byte documents
+
 ## 0.17.0
 
 - [[#107](https://github.com/IronCoreLabs/ironoxide/pull/107)]

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -958,7 +958,10 @@ pub async fn decrypt_document<CR: rand::CryptoRng + rand::RngCore>(
     )?;
 
     aes::decrypt(&mut enc_doc, *sym_key.bytes())
-        .map_err(|e| e.into())
+        .map_err(|e| {
+            println!("map_err: {}", &e);
+            e.into()
+        })
         .map(move |decrypted_doc| DocumentDecryptResult {
             id: doc_meta.0.id,
             name: doc_meta.0.name,

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -957,18 +957,17 @@ pub async fn decrypt_document<CR: rand::CryptoRng + rand::RngCore>(
         &device_private_key.recrypt_key(),
     )?;
 
-    aes::decrypt(&mut enc_doc, *sym_key.bytes())
-        .map_err(|e| {
-            println!("map_err: {}", &e);
-            e.into()
-        })
-        .map(move |decrypted_doc| DocumentDecryptResult {
-            id: doc_meta.0.id,
-            name: doc_meta.0.name,
-            created: doc_meta.0.created,
-            updated: doc_meta.0.updated,
-            decrypted_data: decrypted_doc.to_vec(),
-        })
+    Ok(
+        aes::decrypt(&mut enc_doc, *sym_key.bytes()).map(move |decrypted_doc| {
+            DocumentDecryptResult {
+                id: doc_meta.0.id,
+                name: doc_meta.0.name,
+                created: doc_meta.0.created,
+                updated: doc_meta.0.updated,
+                decrypted_data: decrypted_doc.to_vec(),
+            }
+        })?,
+    )
 }
 
 /// Decrypt the unmanaged document. The caller must provide both the encrypted data as well as the

--- a/tests/document_ops.rs
+++ b/tests/document_ops.rs
@@ -22,6 +22,17 @@ extern crate galvanic_assert;
 extern crate serde_json;
 
 #[test]
+fn doc_roundtrip_empty_data() -> Result<(), IronOxideErr> {
+    let sdk = initialize_sdk()?;
+    let doc = [0u8; 0];
+
+    let doc_result = sdk.document_encrypt(&doc, &Default::default())?;
+    let decrypted_result = sdk.document_decrypt(doc_result.encrypted_data())?;
+
+    Ok(assert_eq!(&doc, decrypted_result.decrypted_data()))
+}
+
+#[test]
 fn doc_create_without_id() -> Result<(), IronOxideErr> {
     let sdk = initialize_sdk()?;
 


### PR DESCRIPTION
See #105 

Decryption had a check to explicitly disallow "empty" encrypted data. The check was also mistakenly disallowing 1 byte. Both restrictions were relaxed and tests introduced.