### PR TITLE
Use stable Rust on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 before_cache:
   - rm -rf /home/travis/.cargo/registry
 rust:
-  - beta
+  - 1.41.0
 branches:
   only:
     - master


### PR DESCRIPTION
Making sure that our issues with stable went away with 1.41.0