### PR TITLE
Adds all-features to docs-rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,9 @@ tokio = {version = "~0.2.0", features = ["macros"]}
 [build-dependencies]
 protobuf-codegen-pure = "~2.10"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [features]
 blocking = ["tokio/rt-threaded"]
 


### PR DESCRIPTION
https://docs.rs/ironoxide isn't showing the `blocking` module. This should instruct docs.rs to use the `--all-features` flag.