### PR TITLE
[#19] Adds configurable timeouts to SDK methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - [[#114]](https://github.com/IronCoreLabs/ironoxide/pull/114)
   - Adds timeouts to all public API methods. Most timeouts use a top-level config set in IronOxideConfig. Some special cases allow for passing an optional timeout directly (rotate_all, user_create, user_verify, generate_new_device). Timeouts apply to both IronOxide and BlockingIronOxide
   - Configs can now be set on BlockingIronOxide. Before, defaults were always used.
-  - Trying out a "open" struct for all config objects to allow for easier construction and access
+  - Trying out an "open" struct for all config objects to allow for easier construction and access
   - Adds dependency on tokio/rt-threaded feature flag
 
 ## 0.18 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.19 (unreleased)
+- [[#114]](https://github.com/IronCoreLabs/ironoxide/pull/114)
+  - Adds timeouts to all public API methods. Most timeouts use a top-level config set in IronOxideConfig. Some special cases allow for passing an optional timeout directly (rotate_all, user_create, user_verify, generate_new_device). Timeouts apply to both IronOxide and BlockingIronOxide
+  - Configs can now be set on BlockingIronOxide. Before, defaults were always used.
+  - Trying out a "open" struct for all config objects to allow for easier construction and access
+  - Adds dependency on tokio/rt-threaded feature flag
+
 ## 0.18 
 
 - [[#112](https://github.com/IronCoreLabs/ironoxide/pull/112)]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,9 +71,6 @@ opt-level = 3
 debug = false
 lto = true
 
-[profile.bench]
-
-
 [[bench]]
 name = "ironoxide_bench"
 harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,8 @@ percent-encoding="~1.0"
 log = "~0.4"
 protobuf = {version = "~2.10", features = ["with-bytes"]}
 vec1 = "~1.4.0"
-tokio = {version = "~0.2.0", features=["time"]}
+# ironoxide requires rt-threaded at runtime, but not at compile time
+tokio = {version = "~0.2.0", features=["time", "rt-threaded"]}
 dashmap = "3.4.0"
 
 [dev-dependencies]
@@ -69,6 +70,9 @@ debug = true
 opt-level = 3
 debug = false
 lto = true
+
+[profile.bench]
+
 
 [[bench]]
 name = "ironoxide_bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ percent-encoding="~1.0"
 log = "~0.4"
 protobuf = {version = "~2.10", features = ["with-bytes"]}
 vec1 = "~1.4.0"
-tokio = {version = "~0.2.0", optional = true}
+tokio = {version = "~0.2.0", features=["time"]}
 dashmap = "3.4.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironoxide"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/benches/ironoxide_bench.rs
+++ b/benches/ironoxide_bench.rs
@@ -1,7 +1,7 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use futures::executor::block_on;
-use ironoxide::config::IronOxideConfig;
 use ironoxide::{
+    config::IronOxideConfig,
     document::{advanced::DocumentAdvancedOps, DocumentEncryptOpts},
     prelude::*,
     DeviceContext, IronOxide,

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -7,7 +7,6 @@
 //!
 //! # Optional
 //! This requires the optional `blocking` feature to be enabled.
-use crate::config::IronOxideConfig;
 pub use crate::internal::{
     document_api::{
         AssociationType, DocAccessEditErr, DocumentAccessResult, DocumentDecryptResult,
@@ -25,6 +24,7 @@ pub use crate::internal::{
     },
 };
 use crate::{
+    config::IronOxideConfig,
     document::{advanced::DocumentAdvancedOps, DocumentEncryptOpts, DocumentOps},
     group::{GroupCreateOpts, GroupOps},
     user::{DeviceCreateOpts, UserCreateOpts, UserOps},

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -55,12 +55,13 @@ impl BlockingIronOxide {
         &self,
         rotations: &PrivateKeyRotationCheckResult,
         password: &str,
+        timeout: Option<std::time::Duration>,
     ) -> Result<(
         Option<UserUpdatePrivateKeyResult>,
         Option<Vec<GroupUpdatePrivateKeyResult>>,
     )> {
         self.runtime
-            .enter(|| block_on(self.ironoxide.rotate_all(rotations, password)))
+            .enter(|| block_on(self.ironoxide.rotate_all(rotations, password, timeout)))
     }
 
     /// See [ironoxide::document::DocumentOps::document_list()](trait.DocumentOps.html#tymethod.document_list)

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -35,6 +35,7 @@ use crate::{
 use futures::executor::block_on;
 use std::collections::HashMap;
 
+#[derive(Debug)]
 /// Struct that is used to make authenticated requests to the IronCore API. Instantiated with the details
 /// of an account's various ids, device, and signing keys. Once instantiated all operations will be
 /// performed in the context of the account provided. Identical to IronOxide but also contains a Runtime.

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -7,6 +7,7 @@
 //!
 //! # Optional
 //! This requires the optional `blocking` feature to be enabled.
+use crate::config::IronOxideConfig;
 pub use crate::internal::{
     document_api::{
         AssociationType, DocAccessEditErr, DocumentAccessResult, DocumentDecryptResult,
@@ -285,9 +286,12 @@ fn create_runtime() -> tokio::runtime::Runtime {
 
 /// Initialize the BlockingIronOxide SDK with a device. Verifies that the provided user/segment exists and the provided device
 /// keys are valid and exist for the provided account. If successful, returns instance of the BlockingIronOxide SDK.
-pub fn initialize(device_context: &DeviceContext) -> Result<BlockingIronOxide> {
+pub fn initialize(
+    device_context: &DeviceContext,
+    config: &IronOxideConfig,
+) -> Result<BlockingIronOxide> {
     let rt = create_runtime();
-    let maybe_io = rt.enter(|| block_on(crate::initialize(device_context, &Default::default())));
+    let maybe_io = rt.enter(|| block_on(crate::initialize(device_context, config)));
     maybe_io.map(|io| BlockingIronOxide {
         ironoxide: io,
         runtime: rt,
@@ -299,14 +303,11 @@ pub fn initialize(device_context: &DeviceContext) -> Result<BlockingIronOxide> {
 /// for private key rotation.
 pub fn initialize_check_rotation(
     device_context: &DeviceContext,
+    config: &IronOxideConfig,
 ) -> Result<InitAndRotationCheck<BlockingIronOxide>> {
     let rt = create_runtime();
-    let maybe_init = rt.enter(|| {
-        block_on(crate::initialize_check_rotation(
-            device_context,
-            &Default::default(),
-        ))
-    });
+    let maybe_init =
+        rt.enter(|| block_on(crate::initialize_check_rotation(device_context, config)));
     maybe_init.map(|init| match init {
         NoRotationNeeded(io) => NoRotationNeeded(BlockingIronOxide {
             ironoxide: io,

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -230,7 +230,14 @@ impl BlockingIronOxide {
         user_create_opts: &UserCreateOpts,
     ) -> Result<UserCreateResult> {
         let rt = create_runtime();
-        rt.enter(|| block_on(IronOxide::user_create(jwt, password, user_create_opts)))
+        rt.enter(|| {
+            block_on(IronOxide::user_create(
+                jwt,
+                password,
+                user_create_opts,
+                None,
+            ))
+        })
     }
     /// See [ironoxide::user::UserOps::user_list_devices()](trait.UserOps.html#tymethod.user_list_devices)
     pub fn user_list_devices(&self) -> Result<UserDeviceListResult> {
@@ -242,6 +249,7 @@ impl BlockingIronOxide {
         jwt: &str,
         password: &str,
         device_create_options: &DeviceCreateOpts,
+        timeout: Option<std::time::Duration>,
     ) -> Result<DeviceAddResult> {
         let rt = create_runtime();
         rt.enter(|| {
@@ -249,6 +257,7 @@ impl BlockingIronOxide {
                 jwt,
                 password,
                 device_create_options,
+                timeout,
             ))
         })
     }
@@ -258,9 +267,12 @@ impl BlockingIronOxide {
             .enter(|| block_on(self.ironoxide.user_delete_device(device_id)))
     }
     /// See [ironoxide::user::UserOps::user_verify()](trait.UserOps.html#tymethod.user_verify)
-    pub fn user_verify(jwt: &str) -> Result<Option<UserResult>> {
+    pub fn user_verify(
+        jwt: &str,
+        timeout: Option<std::time::Duration>,
+    ) -> Result<Option<UserResult>> {
         let rt = create_runtime();
-        rt.enter(|| block_on(IronOxide::user_verify(jwt)))
+        rt.enter(|| block_on(IronOxide::user_verify(jwt, timeout)))
     }
     /// See [ironoxide::user::UserOps::user_get_public_key()](trait.UserOps.html#tymethod.user_get_public_key)
     pub fn user_get_public_key(&self, users: &[UserId]) -> Result<HashMap<UserId, PublicKey>> {

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -229,6 +229,7 @@ impl BlockingIronOxide {
         jwt: &str,
         password: &str,
         user_create_opts: &UserCreateOpts,
+        timeout: Option<std::time::Duration>,
     ) -> Result<UserCreateResult> {
         let rt = create_runtime();
         rt.enter(|| {
@@ -236,7 +237,7 @@ impl BlockingIronOxide {
                 jwt,
                 password,
                 user_create_opts,
-                None,
+                timeout,
             ))
         })
     }

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -35,10 +35,10 @@ use crate::{
 use futures::executor::block_on;
 use std::collections::HashMap;
 
-#[derive(Debug)]
 /// Struct that is used to make authenticated requests to the IronCore API. Instantiated with the details
 /// of an account's various ids, device, and signing keys. Once instantiated all operations will be
 /// performed in the context of the account provided. Identical to IronOxide but also contains a Runtime.
+#[derive(Debug)]
 pub struct BlockingIronOxide {
     pub(crate) ironoxide: IronOxide,
     pub(crate) runtime: tokio::runtime::Runtime,

--- a/src/document/advanced.rs
+++ b/src/document/advanced.rs
@@ -4,7 +4,7 @@ pub use crate::internal::document_api::{
 use crate::internal::run_maybe_timed_sdk_op;
 use crate::{
     document::{partition_user_or_group, DocumentEncryptOpts},
-    internal, Result, SDKOperation,
+    internal, Result, SdkOperation,
 };
 use itertools::EitherOrBoth;
 
@@ -85,7 +85,7 @@ impl DocumentAdvancedOps for crate::IronOxide {
                 policy_grants,
             ),
             self.config.sdk_operation_timeout,
-            SDKOperation::DocumentEncryptUnmanaged,
+            SdkOperation::DocumentEncryptUnmanaged,
         )
         .await?
     }
@@ -104,7 +104,7 @@ impl DocumentAdvancedOps for crate::IronOxide {
                 encrypted_deks,
             ),
             self.config.sdk_operation_timeout,
-            SDKOperation::DocumentDecryptUnmanaged,
+            SdkOperation::DocumentDecryptUnmanaged,
         )
         .await?
     }

--- a/src/document/advanced.rs
+++ b/src/document/advanced.rs
@@ -73,7 +73,7 @@ impl DocumentAdvancedOps for crate::IronOxide {
             };
 
         run_maybe_timed_sdk_op(
-            internal::document_api::encrypted_document_unmanaged(
+            internal::document_api::encrypt_document_unmanaged(
                 self.device.auth(),
                 &self.recrypt,
                 &self.user_master_pub_key,

--- a/src/document/advanced.rs
+++ b/src/document/advanced.rs
@@ -4,7 +4,7 @@ pub use crate::internal::document_api::{
 use crate::{
     document::{partition_user_or_group, DocumentEncryptOpts},
     internal,
-    internal::run_maybe_timed_sdk_op,
+    internal::add_optional_timeout,
     Result, SdkOperation,
 };
 use itertools::EitherOrBoth;
@@ -72,7 +72,7 @@ impl DocumentAdvancedOps for crate::IronOxide {
                 }
             };
 
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             internal::document_api::encrypt_document_unmanaged(
                 self.device.auth(),
                 &self.recrypt,
@@ -96,7 +96,7 @@ impl DocumentAdvancedOps for crate::IronOxide {
         encrypted_data: &[u8],
         encrypted_deks: &[u8],
     ) -> Result<DocumentDecryptUnmanagedResult> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             internal::document_api::decrypt_document_unmanaged(
                 self.device.auth(),
                 &self.recrypt,

--- a/src/document/advanced.rs
+++ b/src/document/advanced.rs
@@ -1,10 +1,11 @@
 pub use crate::internal::document_api::{
     DocumentDecryptUnmanagedResult, DocumentEncryptUnmanagedResult,
 };
-use crate::internal::run_maybe_timed_sdk_op;
 use crate::{
     document::{partition_user_or_group, DocumentEncryptOpts},
-    internal, Result, SdkOperation,
+    internal,
+    internal::run_maybe_timed_sdk_op,
+    Result, SdkOperation,
 };
 use itertools::EitherOrBoth;
 

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -255,11 +255,9 @@ impl DocumentOps for crate::IronOxide {
                 &self.policy_eval_cache,
             ),
         )
-        .map_err(|_| {
-            IronOxideErr::OperationTimedOut(
-                SDKOperation::DocumentEncrypt,
-                self.config.sdk_operation_timeout,
-            )
+        .map_err(|_| IronOxideErr::OperationTimedOut {
+            operation: SDKOperation::DocumentEncrypt,
+            duration: self.config.sdk_operation_timeout,
         })
         .await?
     }

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -3,12 +3,13 @@ pub use crate::internal::document_api::{
     DocumentEncryptResult, DocumentListMeta, DocumentListResult, DocumentMetadataResult,
     UserOrGroup, VisibleGroup, VisibleUser,
 };
-use crate::internal::{run_maybe_timed_sdk_op, SdkOperation};
 use crate::{
     internal::{
         document_api::{self, DocumentId, DocumentName},
         group_api::GroupId,
+        run_maybe_timed_sdk_op,
         user_api::UserId,
+        SdkOperation,
     },
     policy::*,
     Result,

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -3,7 +3,7 @@ pub use crate::internal::document_api::{
     DocumentEncryptResult, DocumentListMeta, DocumentListResult, DocumentMetadataResult,
     UserOrGroup, VisibleGroup, VisibleUser,
 };
-use crate::internal::{run_maybe_timed_sdk_op, SDKOperation};
+use crate::internal::{run_maybe_timed_sdk_op, SdkOperation};
 use crate::{
     internal::{
         document_api::{self, DocumentId, DocumentName},
@@ -203,7 +203,7 @@ impl DocumentOps for crate::IronOxide {
         run_maybe_timed_sdk_op(
             document_api::document_list(self.device.auth()),
             self.config.sdk_operation_timeout,
-            SDKOperation::DocumentList,
+            SdkOperation::DocumentList,
         )
         .await?
     }
@@ -212,7 +212,7 @@ impl DocumentOps for crate::IronOxide {
         run_maybe_timed_sdk_op(
             document_api::document_get_metadata(self.device.auth(), id),
             self.config.sdk_operation_timeout,
-            SDKOperation::DocumentGetMetadata,
+            SdkOperation::DocumentGetMetadata,
         )
         .await?
     }
@@ -262,7 +262,7 @@ impl DocumentOps for crate::IronOxide {
                 &self.policy_eval_cache,
             ),
             self.config.sdk_operation_timeout,
-            SDKOperation::DocumentEncrypt,
+            SdkOperation::DocumentEncrypt,
         )
         .await?
     }
@@ -282,7 +282,7 @@ impl DocumentOps for crate::IronOxide {
                 &new_document_data,
             ),
             self.config.sdk_operation_timeout,
-            SDKOperation::DocumentUpdateBytes,
+            SdkOperation::DocumentUpdateBytes,
         )
         .await?
     }
@@ -296,7 +296,7 @@ impl DocumentOps for crate::IronOxide {
                 encrypted_document,
             ),
             self.config.sdk_operation_timeout,
-            SDKOperation::DocumentDecrypt,
+            SdkOperation::DocumentDecrypt,
         )
         .await?
     }
@@ -309,7 +309,7 @@ impl DocumentOps for crate::IronOxide {
         run_maybe_timed_sdk_op(
             document_api::update_document_name(self.device.auth(), id, name),
             self.config.sdk_operation_timeout,
-            SDKOperation::DocumentUpdateName,
+            SdkOperation::DocumentUpdateName,
         )
         .await?
     }
@@ -332,7 +332,7 @@ impl DocumentOps for crate::IronOxide {
                 &groups,
             ),
             self.config.sdk_operation_timeout,
-            SDKOperation::DocumentGrantAccess,
+            SdkOperation::DocumentGrantAccess,
         )
         .await?
     }
@@ -345,7 +345,7 @@ impl DocumentOps for crate::IronOxide {
         run_maybe_timed_sdk_op(
             document_api::document_revoke_access(self.device.auth(), id, revoke_list),
             self.config.sdk_operation_timeout,
-            SDKOperation::DocumentRevokeAccess,
+            SdkOperation::DocumentRevokeAccess,
         )
         .await?
     }

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -15,7 +15,6 @@ use crate::{
 };
 use futures::prelude::*;
 use itertools::{Either, EitherOrBoth, Itertools};
-use std::time::Duration;
 
 /// Advanced document operations
 pub mod advanced;
@@ -237,9 +236,9 @@ impl DocumentOps for crate::IronOxide {
                     )
                 }
             };
-        let duration = Duration::from_millis(900);
+
         tokio::time::timeout(
-            duration,
+            self.config.sdk_operation_timeout,
             document_api::encrypt_document(
                 self.device.auth(),
                 &self.config,
@@ -256,7 +255,12 @@ impl DocumentOps for crate::IronOxide {
                 &self.policy_eval_cache,
             ),
         )
-        .map_err(|_| IronOxideErr::OperationTimedOut(SDKOperation::DocumentEncrypt, duration))
+        .map_err(|_| {
+            IronOxideErr::OperationTimedOut(
+                SDKOperation::DocumentEncrypt,
+                self.config.sdk_operation_timeout,
+            )
+        })
         .await?
     }
 

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -5,9 +5,9 @@ pub use crate::internal::document_api::{
 };
 use crate::{
     internal::{
+        add_optional_timeout,
         document_api::{self, DocumentId, DocumentName},
         group_api::GroupId,
-        run_maybe_timed_sdk_op,
         user_api::UserId,
         SdkOperation,
     },
@@ -201,7 +201,7 @@ pub trait DocumentOps {
 #[async_trait]
 impl DocumentOps for crate::IronOxide {
     async fn document_list(&self) -> Result<DocumentListResult> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             document_api::document_list(self.device.auth()),
             self.config.sdk_operation_timeout,
             SdkOperation::DocumentList,
@@ -210,7 +210,7 @@ impl DocumentOps for crate::IronOxide {
     }
 
     async fn document_get_metadata(&self, id: &DocumentId) -> Result<DocumentMetadataResult> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             document_api::document_get_metadata(self.device.auth(), id),
             self.config.sdk_operation_timeout,
             SdkOperation::DocumentGetMetadata,
@@ -246,7 +246,7 @@ impl DocumentOps for crate::IronOxide {
                     )
                 }
             };
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             document_api::encrypt_document(
                 self.device.auth(),
                 &self.config,
@@ -273,7 +273,7 @@ impl DocumentOps for crate::IronOxide {
         id: &DocumentId,
         new_document_data: &[u8],
     ) -> Result<DocumentEncryptResult> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             document_api::document_update_bytes(
                 self.device.auth(),
                 &self.recrypt,
@@ -289,7 +289,7 @@ impl DocumentOps for crate::IronOxide {
     }
 
     async fn document_decrypt(&self, encrypted_document: &[u8]) -> Result<DocumentDecryptResult> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             document_api::decrypt_document(
                 self.device.auth(),
                 &self.recrypt,
@@ -307,7 +307,7 @@ impl DocumentOps for crate::IronOxide {
         id: &DocumentId,
         name: Option<&DocumentName>,
     ) -> Result<DocumentMetadataResult> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             document_api::update_document_name(self.device.auth(), id, name),
             self.config.sdk_operation_timeout,
             SdkOperation::DocumentUpdateName,
@@ -322,7 +322,7 @@ impl DocumentOps for crate::IronOxide {
     ) -> Result<DocumentAccessResult> {
         let (users, groups) = partition_user_or_group(grant_list);
 
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             document_api::document_grant_access(
                 self.device.auth(),
                 &self.recrypt,
@@ -343,7 +343,7 @@ impl DocumentOps for crate::IronOxide {
         id: &DocumentId,
         revoke_list: &Vec<UserOrGroup>,
     ) -> Result<DocumentAccessResult> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             document_api::document_revoke_access(self.device.auth(), id, revoke_list),
             self.config.sdk_operation_timeout,
             SdkOperation::DocumentRevokeAccess,

--- a/src/group.rs
+++ b/src/group.rs
@@ -5,7 +5,7 @@ pub use crate::internal::group_api::{
 use crate::internal::run_maybe_timed_sdk_op;
 use crate::{
     internal::{group_api, group_api::GroupCreateOptsStd, user_api::UserId, IronOxideErr},
-    Result, SDKOperation,
+    Result, SdkOperation,
 };
 use vec1::Vec1;
 
@@ -269,7 +269,7 @@ impl GroupOps for crate::IronOxide {
         run_maybe_timed_sdk_op(
             group_api::list(self.device.auth(), None),
             self.config.sdk_operation_timeout,
-            SDKOperation::GroupList,
+            SdkOperation::GroupList,
         )
         .await?
     }
@@ -299,7 +299,7 @@ impl GroupOps for crate::IronOxide {
                 needs_rotation,
             ),
             self.config.sdk_operation_timeout,
-            SDKOperation::GroupCreate,
+            SdkOperation::GroupCreate,
         )
         .await?
     }
@@ -308,7 +308,7 @@ impl GroupOps for crate::IronOxide {
         run_maybe_timed_sdk_op(
             group_api::get_metadata(self.device.auth(), id),
             self.config.sdk_operation_timeout,
-            SDKOperation::GroupGetMetadata,
+            SdkOperation::GroupGetMetadata,
         )
         .await?
     }
@@ -317,7 +317,7 @@ impl GroupOps for crate::IronOxide {
         run_maybe_timed_sdk_op(
             group_api::group_delete(self.device.auth(), id),
             self.config.sdk_operation_timeout,
-            SDKOperation::GroupDelete,
+            SdkOperation::GroupDelete,
         )
         .await?
     }
@@ -330,7 +330,7 @@ impl GroupOps for crate::IronOxide {
         run_maybe_timed_sdk_op(
             group_api::update_group_name(self.device.auth(), id, name),
             self.config.sdk_operation_timeout,
-            SDKOperation::GroupUpdateName,
+            SdkOperation::GroupUpdateName,
         )
         .await?
     }
@@ -349,7 +349,7 @@ impl GroupOps for crate::IronOxide {
                 &grant_list.to_vec(),
             ),
             self.config.sdk_operation_timeout,
-            SDKOperation::GroupAddMembers,
+            SdkOperation::GroupAddMembers,
         )
         .await?
     }
@@ -367,7 +367,7 @@ impl GroupOps for crate::IronOxide {
                 group_api::GroupEntity::Member,
             ),
             self.config.sdk_operation_timeout,
-            SDKOperation::GroupRemoveMembers,
+            SdkOperation::GroupRemoveMembers,
         )
         .await?
     }
@@ -386,7 +386,7 @@ impl GroupOps for crate::IronOxide {
                 &users.to_vec(),
             ),
             self.config.sdk_operation_timeout,
-            SDKOperation::GroupAddAdmins,
+            SdkOperation::GroupAddAdmins,
         )
         .await?
     }
@@ -404,7 +404,7 @@ impl GroupOps for crate::IronOxide {
                 group_api::GroupEntity::Admin,
             ),
             self.config.sdk_operation_timeout,
-            SDKOperation::GroupRemoveAdmins,
+            SdkOperation::GroupRemoveAdmins,
         )
         .await?
     }
@@ -418,7 +418,7 @@ impl GroupOps for crate::IronOxide {
                 self.device().device_private_key(),
             ),
             self.config.sdk_operation_timeout,
-            SDKOperation::GroupRotatePrivateKey,
+            SdkOperation::GroupRotatePrivateKey,
         )
         .await?
     }

--- a/src/group.rs
+++ b/src/group.rs
@@ -2,9 +2,10 @@ pub use crate::internal::group_api::{
     GroupAccessEditErr, GroupAccessEditResult, GroupCreateResult, GroupGetResult, GroupId,
     GroupListResult, GroupMetaResult, GroupName, GroupUpdatePrivateKeyResult,
 };
+use crate::internal::run_maybe_timed_sdk_op;
 use crate::{
     internal::{group_api, group_api::GroupCreateOptsStd, user_api::UserId, IronOxideErr},
-    Result,
+    Result, SDKOperation,
 };
 use vec1::Vec1;
 
@@ -265,7 +266,12 @@ pub trait GroupOps {
 #[async_trait]
 impl GroupOps for crate::IronOxide {
     async fn group_list(&self) -> Result<GroupListResult> {
-        group_api::list(self.device.auth(), None).await
+        run_maybe_timed_sdk_op(
+            group_api::list(self.device.auth(), None),
+            self.config.sdk_operation_timeout,
+            SDKOperation::GroupList,
+        )
+        .await?
     }
 
     async fn group_create(&self, opts: &GroupCreateOpts) -> Result<GroupCreateResult> {
@@ -280,26 +286,40 @@ impl GroupOps for crate::IronOxide {
             needs_rotation,
         } = standard_opts;
 
-        group_api::group_create(
-            &self.recrypt,
-            self.device.auth(),
-            id,
-            name,
-            owner,
-            admins,
-            members,
-            all_users,
-            needs_rotation,
+        run_maybe_timed_sdk_op(
+            group_api::group_create(
+                &self.recrypt,
+                self.device.auth(),
+                id,
+                name,
+                owner,
+                admins,
+                members,
+                all_users,
+                needs_rotation,
+            ),
+            self.config.sdk_operation_timeout,
+            SDKOperation::GroupCreate,
         )
-        .await
+        .await?
     }
 
     async fn group_get_metadata(&self, id: &GroupId) -> Result<GroupGetResult> {
-        group_api::get_metadata(self.device.auth(), id).await
+        run_maybe_timed_sdk_op(
+            group_api::get_metadata(self.device.auth(), id),
+            self.config.sdk_operation_timeout,
+            SDKOperation::GroupGetMetadata,
+        )
+        .await?
     }
 
     async fn group_delete(&self, id: &GroupId) -> Result<GroupId> {
-        group_api::group_delete(self.device.auth(), id).await
+        run_maybe_timed_sdk_op(
+            group_api::group_delete(self.device.auth(), id),
+            self.config.sdk_operation_timeout,
+            SDKOperation::GroupDelete,
+        )
+        .await?
     }
 
     async fn group_update_name(
@@ -307,7 +327,12 @@ impl GroupOps for crate::IronOxide {
         id: &GroupId,
         name: Option<&GroupName>,
     ) -> Result<GroupMetaResult> {
-        group_api::update_group_name(self.device.auth(), id, name).await
+        run_maybe_timed_sdk_op(
+            group_api::update_group_name(self.device.auth(), id, name),
+            self.config.sdk_operation_timeout,
+            SDKOperation::GroupUpdateName,
+        )
+        .await?
     }
 
     async fn group_add_members(
@@ -315,14 +340,18 @@ impl GroupOps for crate::IronOxide {
         id: &GroupId,
         grant_list: &[UserId],
     ) -> Result<GroupAccessEditResult> {
-        group_api::group_add_members(
-            &self.recrypt,
-            self.device.auth(),
-            self.device.device_private_key(),
-            id,
-            &grant_list.to_vec(),
+        run_maybe_timed_sdk_op(
+            group_api::group_add_members(
+                &self.recrypt,
+                self.device.auth(),
+                self.device.device_private_key(),
+                id,
+                &grant_list.to_vec(),
+            ),
+            self.config.sdk_operation_timeout,
+            SDKOperation::GroupAddMembers,
         )
-        .await
+        .await?
     }
 
     async fn group_remove_members(
@@ -330,13 +359,17 @@ impl GroupOps for crate::IronOxide {
         id: &GroupId,
         revoke_list: &[UserId],
     ) -> Result<GroupAccessEditResult> {
-        group_api::group_remove_entity(
-            self.device.auth(),
-            id,
-            &revoke_list.to_vec(),
-            group_api::GroupEntity::Member,
+        run_maybe_timed_sdk_op(
+            group_api::group_remove_entity(
+                self.device.auth(),
+                id,
+                &revoke_list.to_vec(),
+                group_api::GroupEntity::Member,
+            ),
+            self.config.sdk_operation_timeout,
+            SDKOperation::GroupRemoveMembers,
         )
-        .await
+        .await?
     }
 
     async fn group_add_admins(
@@ -344,14 +377,18 @@ impl GroupOps for crate::IronOxide {
         id: &GroupId,
         users: &[UserId],
     ) -> Result<GroupAccessEditResult> {
-        group_api::group_add_admins(
-            &self.recrypt,
-            self.device.auth(),
-            self.device.device_private_key(),
-            id,
-            &users.to_vec(),
+        run_maybe_timed_sdk_op(
+            group_api::group_add_admins(
+                &self.recrypt,
+                self.device.auth(),
+                self.device.device_private_key(),
+                id,
+                &users.to_vec(),
+            ),
+            self.config.sdk_operation_timeout,
+            SDKOperation::GroupAddAdmins,
         )
-        .await
+        .await?
     }
 
     async fn group_remove_admins(
@@ -359,23 +396,31 @@ impl GroupOps for crate::IronOxide {
         id: &GroupId,
         revoke_list: &[UserId],
     ) -> Result<GroupAccessEditResult> {
-        group_api::group_remove_entity(
-            self.device.auth(),
-            id,
-            &revoke_list.to_vec(),
-            group_api::GroupEntity::Admin,
+        run_maybe_timed_sdk_op(
+            group_api::group_remove_entity(
+                self.device.auth(),
+                id,
+                &revoke_list.to_vec(),
+                group_api::GroupEntity::Admin,
+            ),
+            self.config.sdk_operation_timeout,
+            SDKOperation::GroupRemoveAdmins,
         )
-        .await
+        .await?
     }
 
     async fn group_rotate_private_key(&self, id: &GroupId) -> Result<GroupUpdatePrivateKeyResult> {
-        group_api::group_rotate_private_key(
-            &self.recrypt,
-            self.device().auth(),
-            id,
-            self.device().device_private_key(),
+        run_maybe_timed_sdk_op(
+            group_api::group_rotate_private_key(
+                &self.recrypt,
+                self.device().auth(),
+                id,
+                self.device().device_private_key(),
+            ),
+            self.config.sdk_operation_timeout,
+            SDKOperation::GroupRotatePrivateKey,
         )
-        .await
+        .await?
     }
 }
 

--- a/src/group.rs
+++ b/src/group.rs
@@ -2,9 +2,11 @@ pub use crate::internal::group_api::{
     GroupAccessEditErr, GroupAccessEditResult, GroupCreateResult, GroupGetResult, GroupId,
     GroupListResult, GroupMetaResult, GroupName, GroupUpdatePrivateKeyResult,
 };
-use crate::internal::run_maybe_timed_sdk_op;
 use crate::{
-    internal::{group_api, group_api::GroupCreateOptsStd, user_api::UserId, IronOxideErr},
+    internal::{
+        group_api, group_api::GroupCreateOptsStd, run_maybe_timed_sdk_op, user_api::UserId,
+        IronOxideErr,
+    },
     Result, SdkOperation,
 };
 use vec1::Vec1;

--- a/src/group.rs
+++ b/src/group.rs
@@ -4,7 +4,7 @@ pub use crate::internal::group_api::{
 };
 use crate::{
     internal::{
-        group_api, group_api::GroupCreateOptsStd, run_maybe_timed_sdk_op, user_api::UserId,
+        add_optional_timeout, group_api, group_api::GroupCreateOptsStd, user_api::UserId,
         IronOxideErr,
     },
     Result, SdkOperation,
@@ -268,7 +268,7 @@ pub trait GroupOps {
 #[async_trait]
 impl GroupOps for crate::IronOxide {
     async fn group_list(&self) -> Result<GroupListResult> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             group_api::list(self.device.auth(), None),
             self.config.sdk_operation_timeout,
             SdkOperation::GroupList,
@@ -288,7 +288,7 @@ impl GroupOps for crate::IronOxide {
             needs_rotation,
         } = standard_opts;
 
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             group_api::group_create(
                 &self.recrypt,
                 self.device.auth(),
@@ -307,7 +307,7 @@ impl GroupOps for crate::IronOxide {
     }
 
     async fn group_get_metadata(&self, id: &GroupId) -> Result<GroupGetResult> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             group_api::get_metadata(self.device.auth(), id),
             self.config.sdk_operation_timeout,
             SdkOperation::GroupGetMetadata,
@@ -316,7 +316,7 @@ impl GroupOps for crate::IronOxide {
     }
 
     async fn group_delete(&self, id: &GroupId) -> Result<GroupId> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             group_api::group_delete(self.device.auth(), id),
             self.config.sdk_operation_timeout,
             SdkOperation::GroupDelete,
@@ -329,7 +329,7 @@ impl GroupOps for crate::IronOxide {
         id: &GroupId,
         name: Option<&GroupName>,
     ) -> Result<GroupMetaResult> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             group_api::update_group_name(self.device.auth(), id, name),
             self.config.sdk_operation_timeout,
             SdkOperation::GroupUpdateName,
@@ -342,7 +342,7 @@ impl GroupOps for crate::IronOxide {
         id: &GroupId,
         grant_list: &[UserId],
     ) -> Result<GroupAccessEditResult> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             group_api::group_add_members(
                 &self.recrypt,
                 self.device.auth(),
@@ -361,7 +361,7 @@ impl GroupOps for crate::IronOxide {
         id: &GroupId,
         revoke_list: &[UserId],
     ) -> Result<GroupAccessEditResult> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             group_api::group_remove_entity(
                 self.device.auth(),
                 id,
@@ -379,7 +379,7 @@ impl GroupOps for crate::IronOxide {
         id: &GroupId,
         users: &[UserId],
     ) -> Result<GroupAccessEditResult> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             group_api::group_add_admins(
                 &self.recrypt,
                 self.device.auth(),
@@ -398,7 +398,7 @@ impl GroupOps for crate::IronOxide {
         id: &GroupId,
         revoke_list: &[UserId],
     ) -> Result<GroupAccessEditResult> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             group_api::group_remove_entity(
                 self.device.auth(),
                 id,
@@ -412,7 +412,7 @@ impl GroupOps for crate::IronOxide {
     }
 
     async fn group_rotate_private_key(&self, id: &GroupId) -> Result<GroupUpdatePrivateKeyResult> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             group_api::group_rotate_private_key(
                 &self.recrypt,
                 self.device().auth(),

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -1334,7 +1334,7 @@ mod tests {
         let policy_json = r#"{ "usersAndGroups": [ { "type": "group", "id": "data_recovery_abcABC012_.$#|@/:;=+'-f1e11a54-8aa9-4641-aaf3-fb92079499f0", "masterPublicKey": { "x": "GE5XQYcRDRhBcyDpNwlu79x6tshNi111ym1IfxOTIxk=", "y": "amgLgcCEYIPQ4oxinLoAvsO3VG7XTFdRfkG/3tooaZE=" } } ], "invalidUsersAndGroups": [] }"#;
         let policy_grant = PolicyGrant::default();
         let policy_cache = DashMap::new();
-        let config = PolicyCachingConfig::new(3);
+        let config = PolicyCachingConfig { max_entries: 3 };
         let policy_resp: PolicyResponse =
             serde_json::from_str(policy_json).expect("json should parse");
 

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -670,7 +670,7 @@ where
 /// Encrypts a document but does not create the document in the IronCore system.
 /// The resultant DocumentDetachedEncryptResult contains both the EncryptedDeks and the AesEncryptedValue
 /// Both pieces will be required for decryption.
-pub async fn encrypted_document_unmanaged<R1, R2>(
+pub async fn encrypt_document_unmanaged<R1, R2>(
     auth: &RequestAuth,
     recrypt: &Recrypt<Sha256, Ed25519, RandomBytes<R1>>,
     user_master_pub_key: &PublicKey,

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -1,5 +1,5 @@
-use crate::config::{IronOxideConfig, PolicyCachingConfig};
 use crate::{
+    config::{IronOxideConfig, PolicyCachingConfig},
     crypto::{
         aes::{self, AesEncryptedValue},
         transform,

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -114,8 +114,36 @@ pub enum SdkOperation {
 impl std::fmt::Display for SdkOperation {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         let name = match self {
+            SdkOperation::InitializeSdk => "initialize",
+            SdkOperation::InitializeSdkCheckRotation => "initialize_check_rotation",
+            SdkOperation::RotateAll => "rotate_all",
+            SdkOperation::DocumentList => "document_list",
+            SdkOperation::DocumentGetMetadata => "document_get_metadata",
             SdkOperation::DocumentEncrypt => "document_encrypt",
-            _ => panic!(""),
+            SdkOperation::DocumentUpdateBytes => "document_update_bytes",
+            SdkOperation::DocumentDecrypt => "document_decrypt",
+            SdkOperation::DocumentUpdateName => "document_update_name",
+            SdkOperation::DocumentGrantAccess => "document_grant_access",
+            SdkOperation::DocumentRevokeAccess => "document_revoke_access",
+            SdkOperation::DocumentEncryptUnmanaged => "document_encrypt_unmanaged",
+            SdkOperation::DocumentDecryptUnmanaged => "document_decrypt_unmanaged",
+            SdkOperation::UserCreate => "user_create",
+            SdkOperation::UserListDevices => "user_list_devices",
+            SdkOperation::GenerateNewDevice => "generate_new_device",
+            SdkOperation::UserDeleteDevice => "user_delete_device",
+            SdkOperation::UserVerify => "user_verify",
+            SdkOperation::UserGetPublicKey => "user_get_public_key",
+            SdkOperation::UserRotatePrivateKey => "user_rotate_private_key",
+            SdkOperation::GroupList => "group_list",
+            SdkOperation::GroupCreate => "group_create",
+            SdkOperation::GroupGetMetadata => "group_get_metadata",
+            SdkOperation::GroupDelete => "group_delete",
+            SdkOperation::GroupUpdateName => "group_update_name",
+            SdkOperation::GroupAddMembers => "group_add_members",
+            SdkOperation::GroupRemoveMembers => "group_remove_members",
+            SdkOperation::GroupAddAdmins => "group_add_admin",
+            SdkOperation::GroupRemoveAdmins => "group_remove_admin",
+            SdkOperation::GroupRotatePrivateKey => "group_rotate_private_key",
         };
         f.write_str(name)
     }
@@ -890,6 +918,11 @@ fn gen_plaintext_and_aug_with_retry<R: CryptoOps>(
     aug_private_key().or_else(|_| aug_private_key())
 }
 
+/// Runs a future with a timeout or just runs the future, depending on if a timeout is specified.
+///
+/// If a timeout limit is reached, the result will be an IronOxideErr::OperationTimedOut.
+/// If no timeout is specified, or if the operation finishes before the timeout, the
+/// result is the result of the sdk operation.
 pub async fn run_maybe_timed_sdk_op<F>(
     f: F,
     timeout: Option<std::time::Duration>,

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -112,39 +112,7 @@ pub enum SdkOperation {
 
 impl std::fmt::Display for SdkOperation {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        let name = match self {
-            SdkOperation::InitializeSdk => "initialize",
-            SdkOperation::InitializeSdkCheckRotation => "initialize_check_rotation",
-            SdkOperation::RotateAll => "rotate_all",
-            SdkOperation::DocumentList => "document_list",
-            SdkOperation::DocumentGetMetadata => "document_get_metadata",
-            SdkOperation::DocumentEncrypt => "document_encrypt",
-            SdkOperation::DocumentUpdateBytes => "document_update_bytes",
-            SdkOperation::DocumentDecrypt => "document_decrypt",
-            SdkOperation::DocumentUpdateName => "document_update_name",
-            SdkOperation::DocumentGrantAccess => "document_grant_access",
-            SdkOperation::DocumentRevokeAccess => "document_revoke_access",
-            SdkOperation::DocumentEncryptUnmanaged => "document_encrypt_unmanaged",
-            SdkOperation::DocumentDecryptUnmanaged => "document_decrypt_unmanaged",
-            SdkOperation::UserCreate => "user_create",
-            SdkOperation::UserListDevices => "user_list_devices",
-            SdkOperation::GenerateNewDevice => "generate_new_device",
-            SdkOperation::UserDeleteDevice => "user_delete_device",
-            SdkOperation::UserVerify => "user_verify",
-            SdkOperation::UserGetPublicKey => "user_get_public_key",
-            SdkOperation::UserRotatePrivateKey => "user_rotate_private_key",
-            SdkOperation::GroupList => "group_list",
-            SdkOperation::GroupCreate => "group_create",
-            SdkOperation::GroupGetMetadata => "group_get_metadata",
-            SdkOperation::GroupDelete => "group_delete",
-            SdkOperation::GroupUpdateName => "group_update_name",
-            SdkOperation::GroupAddMembers => "group_add_members",
-            SdkOperation::GroupRemoveMembers => "group_remove_members",
-            SdkOperation::GroupAddAdmins => "group_add_admin",
-            SdkOperation::GroupRemoveAdmins => "group_remove_admin",
-            SdkOperation::GroupRotatePrivateKey => "group_rotate_private_key",
-        };
-        f.write_str(name)
+        write!(f, "'{:?}'", self)
     }
 }
 

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -156,7 +156,7 @@ quick_error! {
         GroupPrivateKeyRotationError(msg: String) {
             display("Group private key rotation failed with '{}'", msg)
         }
-        OperationTimedOut(operation: SDKOperation, duration: std::time::Duration) {
+        OperationTimedOut{operation: SDKOperation, duration: std::time::Duration} {
             display("Operation {} timed out after {}ms", operation, duration.as_millis())
         }
     }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -17,6 +17,8 @@ use recrypt::api::{
 };
 use regex::Regex;
 use reqwest::Method;
+use serde::export::fmt::Error;
+use serde::export::Formatter;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     convert::{TryFrom, TryInto},
@@ -70,6 +72,20 @@ pub enum RequestErrorCode {
     DocumentRevokeAccess,
     EdekTransform,
     PolicyGet,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
+pub enum SDKOperation {
+    DocumentEncrypt,
+}
+
+impl std::fmt::Display for SDKOperation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+        let name = match self {
+            SDKOperation::DocumentEncrypt => "document_encrypt",
+        };
+        f.write_str(name)
+    }
 }
 
 quick_error! {
@@ -139,6 +155,9 @@ quick_error! {
         }
         GroupPrivateKeyRotationError(msg: String) {
             display("Group private key rotation failed with '{}'", msg)
+        }
+        OperationTimedOut(operation: SDKOperation, duration: std::time::Duration) {
+            display("Operation {} timed out after {}ms", operation, duration.as_millis())
         }
     }
 }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -76,8 +76,9 @@ pub enum RequestErrorCode {
     PolicyGet,
 }
 
+/// Public SDK operations
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
-pub enum SDKOperation {
+pub enum SdkOperation {
     InitializeSdk,
     InitializeSdkCheckRotation,
     RotateAll,
@@ -110,10 +111,10 @@ pub enum SDKOperation {
     GroupRotatePrivateKey,
 }
 
-impl std::fmt::Display for SDKOperation {
+impl std::fmt::Display for SdkOperation {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         let name = match self {
-            SDKOperation::DocumentEncrypt => "document_encrypt",
+            SdkOperation::DocumentEncrypt => "document_encrypt",
             _ => panic!(""),
         };
         f.write_str(name)
@@ -188,7 +189,7 @@ quick_error! {
         GroupPrivateKeyRotationError(msg: String) {
             display("Group private key rotation failed with '{}'", msg)
         }
-        OperationTimedOut{operation: SDKOperation, duration: std::time::Duration} {
+        OperationTimedOut{operation: SdkOperation, duration: std::time::Duration} {
             display("Operation {} timed out after {}ms", operation, duration.as_millis())
         }
     }
@@ -892,7 +893,7 @@ fn gen_plaintext_and_aug_with_retry<R: CryptoOps>(
 pub async fn run_maybe_timed_sdk_op<F>(
     f: F,
     timeout: Option<std::time::Duration>,
-    op: SDKOperation,
+    op: SdkOperation,
 ) -> Result<F::Output, IronOxideErr>
 where
     F: Future,
@@ -1397,14 +1398,14 @@ pub(crate) mod tests {
         }
         let forty_two = get_42();
         let result =
-            run_maybe_timed_sdk_op(forty_two, None, SDKOperation::DocumentRevokeAccess).await?;
+            run_maybe_timed_sdk_op(forty_two, None, SdkOperation::DocumentRevokeAccess).await?;
         assert_eq!(result, 42);
 
         let forty_two = get_42();
         let result = run_maybe_timed_sdk_op(
             forty_two,
             Some(Duration::from_secs(1)),
-            SDKOperation::DocumentRevokeAccess,
+            SdkOperation::DocumentRevokeAccess,
         )
         .await?;
         assert_eq!(result, 42);
@@ -1416,7 +1417,7 @@ pub(crate) mod tests {
 
         let err_f = get_err();
         let result =
-            run_maybe_timed_sdk_op(err_f, None, SDKOperation::DocumentRevokeAccess).await?;
+            run_maybe_timed_sdk_op(err_f, None, SdkOperation::DocumentRevokeAccess).await?;
         assert!(result.is_err());
         assert_that!(
             &result.unwrap_err(),
@@ -1427,7 +1428,7 @@ pub(crate) mod tests {
         let result = run_maybe_timed_sdk_op(
             err_f,
             Some(Duration::from_secs(1)),
-            SDKOperation::DocumentRevokeAccess,
+            SdkOperation::DocumentRevokeAccess,
         )
         .await?;
         assert!(result.is_err());
@@ -1452,7 +1453,7 @@ pub(crate) mod tests {
         let result = run_maybe_timed_sdk_op(
             forty_two,
             Some(Duration::from_nanos(1)),
-            SDKOperation::DocumentRevokeAccess,
+            SdkOperation::DocumentRevokeAccess,
         )
         .await;
         assert!(result.is_err());
@@ -1470,7 +1471,7 @@ pub(crate) mod tests {
         let result = run_maybe_timed_sdk_op(
             err_f,
             Some(Duration::from_millis(1)),
-            SDKOperation::DocumentRevokeAccess,
+            SdkOperation::DocumentRevokeAccess,
         )
         .await;
         assert!(result.is_err());

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -890,7 +890,7 @@ fn gen_plaintext_and_aug_with_retry<R: CryptoOps>(
 /// If a timeout limit is reached, the result will be an IronOxideErr::OperationTimedOut.
 /// If no timeout is specified, or if the operation finishes before the timeout, the
 /// result is the result of the sdk operation.
-pub async fn run_maybe_timed_sdk_op<F: Future>(
+pub async fn add_optional_timeout<F: Future>(
     f: F,
     timeout: Option<std::time::Duration>,
     op: SdkOperation,
@@ -1395,11 +1395,11 @@ pub(crate) mod tests {
         }
         let forty_two = get_42();
         let result =
-            run_maybe_timed_sdk_op(forty_two, None, SdkOperation::DocumentRevokeAccess).await?;
+            add_optional_timeout(forty_two, None, SdkOperation::DocumentRevokeAccess).await?;
         assert_eq!(result, 42);
 
         let forty_two = get_42();
-        let result = run_maybe_timed_sdk_op(
+        let result = add_optional_timeout(
             forty_two,
             Some(Duration::from_secs(1)),
             SdkOperation::DocumentRevokeAccess,
@@ -1413,8 +1413,7 @@ pub(crate) mod tests {
         }
 
         let err_f = get_err();
-        let result =
-            run_maybe_timed_sdk_op(err_f, None, SdkOperation::DocumentRevokeAccess).await?;
+        let result = add_optional_timeout(err_f, None, SdkOperation::DocumentRevokeAccess).await?;
         assert!(result.is_err());
         assert_that!(
             &result.unwrap_err(),
@@ -1422,7 +1421,7 @@ pub(crate) mod tests {
         );
 
         let err_f = get_err();
-        let result = run_maybe_timed_sdk_op(
+        let result = add_optional_timeout(
             err_f,
             Some(Duration::from_secs(1)),
             SdkOperation::DocumentRevokeAccess,
@@ -1447,7 +1446,7 @@ pub(crate) mod tests {
         }
 
         let forty_two = get_42();
-        let result = run_maybe_timed_sdk_op(
+        let result = add_optional_timeout(
             forty_two,
             Some(Duration::from_nanos(1)),
             SdkOperation::DocumentRevokeAccess,
@@ -1465,7 +1464,7 @@ pub(crate) mod tests {
         }
 
         let err_f = get_err();
-        let result = run_maybe_timed_sdk_op(
+        let result = add_optional_timeout(
             err_f,
             Some(Duration::from_millis(1)),
             SdkOperation::DocumentRevokeAccess,

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -83,7 +83,6 @@ pub enum SDKOperation {
     RotateAll,
     DocumentList,
     DocumentGetMetadata,
-    DocumentGetIdFromBytes,
     DocumentEncrypt,
     DocumentUpdateBytes,
     DocumentDecrypt,

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -18,11 +18,10 @@ use recrypt::api::{
 };
 use regex::Regex;
 use reqwest::Method;
-use serde::export::fmt::Error;
-use serde::export::Formatter;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::{
     convert::{TryFrom, TryInto},
+    fmt::{Error, Formatter},
     result::Result,
     sync::{Mutex, MutexGuard},
 };
@@ -923,14 +922,11 @@ fn gen_plaintext_and_aug_with_retry<R: CryptoOps>(
 /// If a timeout limit is reached, the result will be an IronOxideErr::OperationTimedOut.
 /// If no timeout is specified, or if the operation finishes before the timeout, the
 /// result is the result of the sdk operation.
-pub async fn run_maybe_timed_sdk_op<F>(
+pub async fn run_maybe_timed_sdk_op<F: Future>(
     f: F,
     timeout: Option<std::time::Duration>,
     op: SdkOperation,
-) -> Result<F::Output, IronOxideErr>
-where
-    F: Future,
-{
+) -> Result<F::Output, IronOxideErr> {
     use futures::future::TryFutureExt;
     let result = match timeout {
         Some(d) => {
@@ -939,7 +935,7 @@ where
                     operation: op,
                     duration: d,
                 })
-                .await? // ? here returns the OperationTimedOut error
+                .await?
         }
 
         // no timeout, just run the Future and return

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,8 +97,7 @@ use rand::{
 };
 use rand_chacha::ChaChaCore;
 use recrypt::api::{Ed25519, RandomBytes, Recrypt, Sha256};
-use serde::export::fmt::{Debug, Error};
-use serde::export::Formatter;
+use std::fmt;
 use std::{convert::TryInto, sync::Mutex};
 use vec1::Vec1;
 
@@ -160,9 +159,25 @@ pub struct IronOxide {
     pub(crate) policy_eval_cache: PolicyCache,
 }
 
-impl Debug for IronOxide {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::result::Result<(), Error> {
-        unimplemented!()
+impl fmt::Debug for IronOxide {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            IronOxide {
+                config: ref __self_0_0,
+                recrypt: _,
+                user_master_pub_key: ref __self_0_2,
+                device: ref __self_0_3,
+                rng: _,
+                policy_eval_cache: ref __self_0_5,
+            } => {
+                let mut debug_trait_builder = f.debug_struct("IronOxide");
+                let _ = debug_trait_builder.field("config", &&(*__self_0_0));
+                let _ = debug_trait_builder.field("user_master_pub_key", &&(*__self_0_2));
+                let _ = debug_trait_builder.field("device", &&(*__self_0_3));
+                let _ = debug_trait_builder.field("policy_eval_cache", &&(*__self_0_5));
+                debug_trait_builder.finish()
+            }
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ use crate::internal::{
 };
 pub use crate::internal::{
     DeviceAddResult, DeviceContext, DeviceSigningKeyPair, IronOxideErr, KeyPair, PrivateKey,
-    PublicKey,
+    PublicKey, SDKOperation,
 };
 use crate::policy::PolicyGrant;
 use dashmap::DashMap;
@@ -105,7 +105,7 @@ type PolicyCache = DashMap<PolicyGrant, Vec<WithKey<UserOrGroup>>>;
 
 /// IronOxide SDK configuration
 pub mod config {
-    use tokio::time::Duration;
+    use std::time::Duration;
 
     /// Top-level configuration object for IronOxide.
     #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,25 +159,15 @@ pub struct IronOxide {
     pub(crate) policy_eval_cache: PolicyCache,
 }
 
+/// Manual implementation of Debug without the `recrypt` or `rng` fields
 impl fmt::Debug for IronOxide {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            IronOxide {
-                config: ref __self_0_0,
-                recrypt: _,
-                user_master_pub_key: ref __self_0_2,
-                device: ref __self_0_3,
-                rng: _,
-                policy_eval_cache: ref __self_0_5,
-            } => {
-                let mut debug_trait_builder = f.debug_struct("IronOxide");
-                let _ = debug_trait_builder.field("config", &&(*__self_0_0));
-                let _ = debug_trait_builder.field("user_master_pub_key", &&(*__self_0_2));
-                let _ = debug_trait_builder.field("device", &&(*__self_0_3));
-                let _ = debug_trait_builder.field("policy_eval_cache", &&(*__self_0_5));
-                debug_trait_builder.finish()
-            }
-        }
+        f.debug_struct("IronOxide")
+            .field("config", &self.config)
+            .field("user_master_pub_key", &self.user_master_pub_key)
+            .field("device", &self.device)
+            .field("policy_eval_cache", &self.policy_eval_cache)
+            .finish()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,16 +105,15 @@ type PolicyCache = DashMap<PolicyGrant, Vec<WithKey<UserOrGroup>>>;
 
 /// IronOxide SDK configuration
 pub mod config {
+    use tokio::time::Duration;
 
+    /// Top-level configuration object for IronOxide.
     #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
     pub struct IronOxideConfig {
-        pub(crate) policy_caching: PolicyCachingConfig,
-    }
-
-    impl IronOxideConfig {
-        pub fn new(policy_caching: PolicyCachingConfig) -> IronOxideConfig {
-            IronOxideConfig { policy_caching }
-        }
+        /// See [PolicyCachingConfig](struct.PolicyCachingConfig.html)
+        pub policy_caching: PolicyCachingConfig,
+        /// Timeout for all SDK methods. Will return IronOxideErr::OperationTimedOut on timeout.
+        pub sdk_operation_timeout: Duration,
     }
 
     /// Policy evaluation caching config. Lifetime of the cache is the lifetime of the `IronOxide` struct.
@@ -124,26 +123,16 @@ pub mod config {
     /// if you want to clear it at runtime, call [IronOxide::clear_policy_cache()](../struct.IronOxide.html#method.clear_policy_cache).
     #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
     pub struct PolicyCachingConfig {
-        pub(crate) max_entries: usize,
-    }
-
-    impl PolicyCachingConfig {
-        /// # Arguments
-        /// `max_entries` - maximum number of policy evaluations that will be cached by the SDK.
-        /// If the maximum number is exceeded, the cache will be cleared prior to storing the next entry.
-        pub fn new(max_entries: usize) -> PolicyCachingConfig {
-            PolicyCachingConfig { max_entries }
-        }
-
-        pub fn max_entries(&self) -> usize {
-            self.max_entries
-        }
+        /// maximum number of policy evaluations that will be cached by the SDK.
+        /// If the maximum number is exceeded, the cache will be cleared prior to storing the next entry
+        pub max_entries: usize,
     }
 
     impl Default for IronOxideConfig {
         fn default() -> Self {
             IronOxideConfig {
                 policy_caching: PolicyCachingConfig::default(),
+                sdk_operation_timeout: Duration::from_secs(30),
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,19 +76,21 @@ pub mod policy;
 /// Convenience re-export of essential IronOxide types
 pub mod prelude;
 
-use crate::config::IronOxideConfig;
-use crate::internal::document_api::UserOrGroup;
-use crate::internal::{
-    group_api::{GroupId, GroupUpdatePrivateKeyResult},
-    run_maybe_timed_sdk_op,
-    user_api::{UserId, UserResult, UserUpdatePrivateKeyResult},
-    WithKey,
-};
 pub use crate::internal::{
     DeviceAddResult, DeviceContext, DeviceSigningKeyPair, IronOxideErr, KeyPair, PrivateKey,
     PublicKey, SdkOperation,
 };
-use crate::policy::PolicyGrant;
+use crate::{
+    config::IronOxideConfig,
+    internal::{
+        document_api::UserOrGroup,
+        group_api::{GroupId, GroupUpdatePrivateKeyResult},
+        run_maybe_timed_sdk_op,
+        user_api::{UserId, UserResult, UserUpdatePrivateKeyResult},
+        WithKey,
+    },
+    policy::PolicyGrant,
+};
 use dashmap::DashMap;
 use itertools::EitherOrBoth;
 use rand::{
@@ -97,8 +99,7 @@ use rand::{
 };
 use rand_chacha::ChaChaCore;
 use recrypt::api::{Ed25519, RandomBytes, Recrypt, Sha256};
-use std::fmt;
-use std::{convert::TryInto, sync::Mutex};
+use std::{convert::TryInto, fmt, sync::Mutex};
 use vec1::Vec1;
 
 /// Result of an Sdk operation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,7 +89,6 @@ pub use crate::internal::{
 };
 use crate::policy::PolicyGrant;
 use dashmap::DashMap;
-use futures::future::TryFutureExt;
 use itertools::EitherOrBoth;
 use rand::{
     rngs::{adapter::ReseedingRng, EntropyRng},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,9 +83,9 @@ pub use crate::internal::{
 use crate::{
     config::IronOxideConfig,
     internal::{
+        add_optional_timeout,
         document_api::UserOrGroup,
         group_api::{GroupId, GroupUpdatePrivateKeyResult},
-        run_maybe_timed_sdk_op,
         user_api::{UserId, UserResult, UserUpdatePrivateKeyResult},
         WithKey,
     },
@@ -230,7 +230,7 @@ pub async fn initialize(
     device_context: &DeviceContext,
     config: &IronOxideConfig,
 ) -> Result<IronOxide> {
-    internal::run_maybe_timed_sdk_op(
+    internal::add_optional_timeout(
         internal::user_api::user_get_current(&device_context.auth()),
         config.sdk_operation_timeout,
         SdkOperation::InitializeSdk,
@@ -275,7 +275,7 @@ pub async fn initialize_check_rotation(
     device_context: &DeviceContext,
     config: &IronOxideConfig,
 ) -> Result<InitAndRotationCheck<IronOxide>> {
-    let (curr_user, group_list_result) = run_maybe_timed_sdk_op(
+    let (curr_user, group_list_result) = add_optional_timeout(
         futures::future::try_join(
             internal::user_api::user_get_current(device_context.auth()),
             internal::group_api::list(device_context.auth(), None),
@@ -374,7 +374,7 @@ impl IronOxide {
         });
         let user_opt_future: futures::future::OptionFuture<_> = user_future.into();
         let group_opt_future: futures::future::OptionFuture<_> = group_futures.into();
-        let (user_opt_result, group_opt_vec_result) = run_maybe_timed_sdk_op(
+        let (user_opt_result, group_opt_vec_result) = add_optional_timeout(
             futures::future::join(user_opt_future, group_opt_future),
             timeout,
             SdkOperation::RotateAll,

--- a/src/user.rs
+++ b/src/user.rs
@@ -8,7 +8,7 @@ use crate::{
         user_api::{self, DeviceId, DeviceName},
         DeviceAddResult, PublicKey, OUR_REQUEST,
     },
-    IronOxide, Result, SDKOperation,
+    IronOxide, Result, SdkOperation,
 };
 use recrypt::api::Recrypt;
 use std::{collections::HashMap, convert::TryInto};
@@ -169,7 +169,7 @@ impl UserOps for IronOxide {
                 *OUR_REQUEST,
             ),
             timeout,
-            SDKOperation::UserCreate,
+            SdkOperation::UserCreate,
         )
         .await?
     }
@@ -178,7 +178,7 @@ impl UserOps for IronOxide {
         run_maybe_timed_sdk_op(
             user_api::device_list(self.device.auth()),
             self.config.sdk_operation_timeout,
-            SDKOperation::UserListDevices,
+            SdkOperation::UserListDevices,
         )
         .await?
     }
@@ -203,7 +203,7 @@ impl UserOps for IronOxide {
                 &OUR_REQUEST,
             ),
             timeout,
-            SDKOperation::GenerateNewDevice,
+            SdkOperation::GenerateNewDevice,
         )
         .await?
     }
@@ -212,7 +212,7 @@ impl UserOps for IronOxide {
         run_maybe_timed_sdk_op(
             user_api::device_delete(self.device.auth(), device_id),
             self.config.sdk_operation_timeout,
-            SDKOperation::UserDeleteDevice,
+            SdkOperation::UserDeleteDevice,
         )
         .await?
     }
@@ -224,7 +224,7 @@ impl UserOps for IronOxide {
         run_maybe_timed_sdk_op(
             user_api::user_verify(jwt.try_into()?, *OUR_REQUEST),
             timeout,
-            SDKOperation::UserVerify,
+            SdkOperation::UserVerify,
         )
         .await?
     }
@@ -233,7 +233,7 @@ impl UserOps for IronOxide {
         run_maybe_timed_sdk_op(
             user_api::user_key_list(self.device.auth(), &users.to_vec()),
             self.config.sdk_operation_timeout,
-            SDKOperation::UserGetPublicKey,
+            SdkOperation::UserGetPublicKey,
         )
         .await?
     }
@@ -246,7 +246,7 @@ impl UserOps for IronOxide {
                 self.device().auth(),
             ),
             self.config.sdk_operation_timeout,
-            SDKOperation::UserRotatePrivateKey,
+            SdkOperation::UserRotatePrivateKey,
         )
         .await?
     }

--- a/src/user.rs
+++ b/src/user.rs
@@ -4,7 +4,7 @@ pub use crate::internal::user_api::{
 };
 use crate::{
     internal::{
-        run_maybe_timed_sdk_op,
+        add_optional_timeout,
         user_api::{self, DeviceId, DeviceName},
         DeviceAddResult, PublicKey, OUR_REQUEST,
     },
@@ -160,7 +160,7 @@ impl UserOps for IronOxide {
         timeout: Option<std::time::Duration>,
     ) -> Result<UserCreateResult> {
         let recrypt = Recrypt::new();
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             user_api::user_create(
                 &recrypt,
                 jwt.try_into()?,
@@ -175,7 +175,7 @@ impl UserOps for IronOxide {
     }
 
     async fn user_list_devices(&self) -> Result<UserDeviceListResult> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             user_api::device_list(self.device.auth()),
             self.config.sdk_operation_timeout,
             SdkOperation::UserListDevices,
@@ -193,7 +193,7 @@ impl UserOps for IronOxide {
 
         let device_create_options = device_create_options.clone();
 
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             user_api::generate_device_key(
                 &recrypt,
                 &jwt.try_into()?,
@@ -209,7 +209,7 @@ impl UserOps for IronOxide {
     }
 
     async fn user_delete_device(&self, device_id: Option<&DeviceId>) -> Result<DeviceId> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             user_api::device_delete(self.device.auth(), device_id),
             self.config.sdk_operation_timeout,
             SdkOperation::UserDeleteDevice,
@@ -221,7 +221,7 @@ impl UserOps for IronOxide {
         jwt: &str,
         timeout: Option<std::time::Duration>,
     ) -> Result<Option<UserResult>> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             user_api::user_verify(jwt.try_into()?, *OUR_REQUEST),
             timeout,
             SdkOperation::UserVerify,
@@ -230,7 +230,7 @@ impl UserOps for IronOxide {
     }
 
     async fn user_get_public_key(&self, users: &[UserId]) -> Result<HashMap<UserId, PublicKey>> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             user_api::user_key_list(self.device.auth(), &users.to_vec()),
             self.config.sdk_operation_timeout,
             SdkOperation::UserGetPublicKey,
@@ -239,7 +239,7 @@ impl UserOps for IronOxide {
     }
 
     async fn user_rotate_private_key(&self, password: &str) -> Result<UserUpdatePrivateKeyResult> {
-        run_maybe_timed_sdk_op(
+        add_optional_timeout(
             user_api::user_rotate_private_key(
                 &self.recrypt,
                 password.try_into()?,

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,10 +1,10 @@
-use crate::internal::run_maybe_timed_sdk_op;
 pub use crate::internal::user_api::{
     EncryptedPrivateKey, UserCreateResult, UserDevice, UserDeviceListResult, UserId, UserResult,
     UserUpdatePrivateKeyResult,
 };
 use crate::{
     internal::{
+        run_maybe_timed_sdk_op,
         user_api::{self, DeviceId, DeviceName},
         DeviceAddResult, PublicKey, OUR_REQUEST,
     },

--- a/tests/blocking_ops.rs
+++ b/tests/blocking_ops.rs
@@ -120,7 +120,7 @@ mod integration_tests {
         };
 
         let result = ironoxide::blocking::initialize(&device, &config);
-        let err_result = result.unwrap_err(); //TODO Can't do this because ironoxide doesn't provide Debug. open issues recrypt about Debug impls
+        let err_result = result.unwrap_err();
 
         assert_that!(&err_result, is_variant!(IronOxideErr::OperationTimedOut));
         assert_that!(
@@ -162,7 +162,7 @@ mod integration_tests {
         {
             let result = bio.rotate_all(&to_rotate, USER_PASSWORD, Some(Duration::from_millis(10)));
 
-            let err_result = result.unwrap_err(); //TODO Can't do this because ironoxide doesn't provide Debug. open issues recrypt about Debug impls
+            let err_result = result.unwrap_err();
 
             assert_that!(&err_result, is_variant!(IronOxideErr::OperationTimedOut));
             assert_that!(

--- a/tests/blocking_ops.rs
+++ b/tests/blocking_ops.rs
@@ -93,7 +93,7 @@ mod integration_tests {
 
     // Show that SDK operations timeout correctly using BlockingIronOxide
     #[test]
-    fn document_encrypt_with_timeout() -> Result<(), IronOxideErr> {
+    fn initialize_with_timeout() -> Result<(), IronOxideErr> {
         let account_id: UserId = create_id_all_classes("").try_into()?;
         BlockingIronOxide::user_create(
             &gen_jwt(Some(account_id.id())).0,
@@ -108,21 +108,20 @@ mod integration_tests {
         .into();
 
         // set a timeout that is unreasonably small
-        let duration = Duration::from_millis(50);
+        let duration = Duration::from_millis(5);
         let config = IronOxideConfig {
-            sdk_operation_timeout: duration,
+            sdk_operation_timeout: Some(duration),
             ..Default::default()
         };
 
-        let sdk = ironoxide::blocking::initialize(&device, &config)?;
-        let doc = [0u8; 64];
-        let result = sdk.document_encrypt(&doc, &Default::default());
-        let err_result = result.unwrap_err();
+        let result = ironoxide::blocking::initialize(&device, &config);
+        let err_result = result.unwrap_err(); //TODO Can't do this because ironoxide doesn't provide Debug. open issues recrypt about Debug impls
+
         assert_that!(&err_result, is_variant!(IronOxideErr::OperationTimedOut));
         assert_that!(
             &err_result,
             has_structure!(IronOxideErr::OperationTimedOut {
-                operation: eq(SDKOperation::DocumentEncrypt),
+                operation: eq(SDKOperation::InitializeSdk),
                 duration: eq(*duration)
             })
         );

--- a/tests/blocking_ops.rs
+++ b/tests/blocking_ops.rs
@@ -27,6 +27,7 @@ mod integration_tests {
             &gen_jwt(Some(account_id.id())).0,
             USER_PASSWORD,
             &Default::default(),
+            None,
         )?
         .into();
         let creator_sdk = ironoxide::blocking::initialize(&device, &Default::default())?;
@@ -55,7 +56,7 @@ mod integration_tests {
         assert!(group_result.is_some());
         assert_eq!(group_result.unwrap().len(), 1);
 
-        let user_result = BlockingIronOxide::user_verify(&jwt)?;
+        let user_result = BlockingIronOxide::user_verify(&jwt, None)?;
         assert!(!user_result.unwrap().needs_rotation());
         let group_get_result = creator_sdk.group_get_metadata(group_create.id())?;
         assert!(!group_get_result.needs_rotation().unwrap());
@@ -76,6 +77,7 @@ mod integration_tests {
             &gen_jwt(Some(account_id.id())).0,
             USER_PASSWORD,
             &Default::default(),
+            None,
         )?
         .into();
         let sdk = ironoxide::blocking::initialize(&device, &Default::default())?;
@@ -104,6 +106,7 @@ mod integration_tests {
             &gen_jwt(Some(account_id.id())).0,
             USER_PASSWORD,
             &Default::default(),
+            None,
         )?
         .into();
 

--- a/tests/blocking_ops.rs
+++ b/tests/blocking_ops.rs
@@ -20,7 +20,7 @@ mod integration_tests {
     fn rotate_all() -> Result<(), IronOxideErr> {
         let account_id: UserId = create_id_all_classes("").try_into()?;
         let jwt = gen_jwt(Some(account_id.id())).0;
-        BlockingIronOxide::user_create(&jwt, USER_PASSWORD, &UserCreateOpts::new(true))?;
+        BlockingIronOxide::user_create(&jwt, USER_PASSWORD, &UserCreateOpts::new(true), None)?;
         let device = BlockingIronOxide::generate_new_device(
             &gen_jwt(Some(account_id.id())).0,
             USER_PASSWORD,
@@ -72,6 +72,7 @@ mod integration_tests {
             &gen_jwt(Some(account_id.id())).0,
             USER_PASSWORD,
             &UserCreateOpts::new(false),
+            None,
         )?;
         let device = BlockingIronOxide::generate_new_device(
             &gen_jwt(Some(account_id.id())).0,
@@ -101,6 +102,7 @@ mod integration_tests {
             &gen_jwt(Some(account_id.id())).0,
             USER_PASSWORD,
             &UserCreateOpts::new(false),
+            None,
         )?;
         let device = BlockingIronOxide::generate_new_device(
             &gen_jwt(Some(account_id.id())).0,
@@ -110,7 +112,7 @@ mod integration_tests {
         )?
         .into();
 
-        // set a timeout that is unreasonably small
+        // set an initialize timeout that is unreasonably small
         let duration = Duration::from_millis(5);
         let config = IronOxideConfig {
             sdk_operation_timeout: Some(duration),
@@ -139,6 +141,7 @@ mod integration_tests {
             &gen_jwt(Some(account_id.id())).0,
             USER_PASSWORD,
             &UserCreateOpts::new(true),
+            None,
         )?;
         let device = BlockingIronOxide::generate_new_device(
             &gen_jwt(Some(account_id.id())).0,
@@ -148,12 +151,11 @@ mod integration_tests {
         )?
         .into();
 
-        // set a timeout that is unreasonably small
-        let duration = Some(Duration::from_millis(5));
-
         if let InitAndRotationCheck::RotationNeeded(bio, to_rotate) =
             ironoxide::blocking::initialize_check_rotation(&device, &Default::default())?
         {
+            // set a rotate_all timeout that is unreasonably small
+            let duration = Some(Duration::from_millis(5));
             let result = bio.rotate_all(&to_rotate, USER_PASSWORD, duration);
 
             let err_result = result.unwrap_err();

--- a/tests/blocking_ops.rs
+++ b/tests/blocking_ops.rs
@@ -5,17 +5,15 @@ mod common;
 #[cfg(feature = "blocking")]
 mod integration_tests {
     use crate::common::{create_id_all_classes, gen_jwt, USER_PASSWORD};
-    use galvanic_assert::matchers::*;
-    use galvanic_assert::*;
-    use ironoxide::config::IronOxideConfig;
+    use galvanic_assert::{matchers::*, *};
     use ironoxide::{
         blocking::BlockingIronOxide,
+        config::IronOxideConfig,
         group::GroupCreateOpts,
         user::{UserCreateOpts, UserId},
         InitAndRotationCheck, IronOxideErr, SdkOperation,
     };
-    use std::convert::TryInto;
-    use std::time::Duration;
+    use std::{convert::TryInto, time::Duration};
     // Tests a UserOp (user_create/generate_new_device), a GroupOp (group_create),
     // and ironoxide::blocking functions (initialize/initialize_check_rotation)
     #[test]
@@ -151,16 +149,12 @@ mod integration_tests {
         .into();
 
         // set a timeout that is unreasonably small
-        let duration = Duration::from_millis(5);
-        let config = IronOxideConfig {
-            sdk_operation_timeout: Some(duration),
-            ..Default::default()
-        };
+        let duration = Some(Duration::from_millis(5));
 
         if let InitAndRotationCheck::RotationNeeded(bio, to_rotate) =
             ironoxide::blocking::initialize_check_rotation(&device, &Default::default())?
         {
-            let result = bio.rotate_all(&to_rotate, USER_PASSWORD, Some(Duration::from_millis(10)));
+            let result = bio.rotate_all(&to_rotate, USER_PASSWORD, duration);
 
             let err_result = result.unwrap_err();
 
@@ -174,8 +168,7 @@ mod integration_tests {
             );
             Ok(())
         } else {
-            // error type here is bogus, but will cause the test to fail
-            Err(IronOxideErr::InitializeError)
+            panic!("rotation should be required")
         }
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -172,7 +172,7 @@ pub async fn init_sdk_get_init_result(
         users_signing_keys_bytes.try_into().unwrap(),
     );
     let config = IronOxideConfig {
-        sdk_operation_timeout: Duration::from_secs(3),
+        sdk_operation_timeout: Some(Duration::from_secs(3)),
         ..Default::default()
     };
     (

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,3 +1,4 @@
+use ironoxide::config::IronOxideConfig;
 use ironoxide::{
     prelude::*,
     user::{UserCreateOpts, UserResult},
@@ -5,6 +6,7 @@ use ironoxide::{
 };
 use lazy_static::*;
 use std::{convert::TryInto, default::Default};
+use tokio::time::Duration;
 use uuid::Uuid;
 
 pub const USER_PASSWORD: &str = "foo";
@@ -169,9 +171,13 @@ pub async fn init_sdk_get_init_result(
         users_device_private_key_bytes.try_into().unwrap(),
         users_signing_keys_bytes.try_into().unwrap(),
     );
+    let config = IronOxideConfig {
+        sdk_operation_timeout: Duration::from_secs(3),
+        ..Default::default()
+    };
     (
         account_id,
-        ironoxide::initialize_check_rotation(&device_init, &Default::default())
+        ironoxide::initialize_check_rotation(&device_init, &config)
             .await
             .unwrap(),
     )

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -117,12 +117,14 @@ pub async fn init_sdk_with_config(config: &IronOxideConfig) -> Result<IronOxide,
         &gen_jwt(Some(account_id.id())).0,
         USER_PASSWORD,
         &UserCreateOpts::new(false),
+        None,
     )
     .await?;
     let device = IronOxide::generate_new_device(
         &gen_jwt(Some(account_id.id())).0,
         USER_PASSWORD,
         &Default::default(),
+        None,
     )
     .await?;
     ironoxide::initialize(&device.into(), config).await
@@ -143,11 +145,12 @@ pub async fn init_sdk_get_init_result(
         &gen_jwt(Some(account_id.id())).0,
         USER_PASSWORD,
         &UserCreateOpts::new(user_needs_rotation),
+        None,
     )
     .await
     .unwrap();
 
-    let verify_resp = IronOxide::user_verify(&gen_jwt(Some(account_id.id())).0)
+    let verify_resp = IronOxide::user_verify(&gen_jwt(Some(account_id.id())).0, None)
         .await
         .unwrap()
         .unwrap();
@@ -157,6 +160,7 @@ pub async fn init_sdk_get_init_result(
         &gen_jwt(Some(account_id.id())).0,
         USER_PASSWORD,
         &Default::default(),
+        None,
     )
     .await
     .unwrap();
@@ -190,10 +194,11 @@ pub async fn init_sdk_get_init_result(
 #[allow(dead_code)]
 pub async fn create_second_user() -> UserResult {
     let (jwt, _) = gen_jwt(Some(&create_id_all_classes("")));
-    let create_result = IronOxide::user_create(&jwt, USER_PASSWORD, &Default::default()).await;
+    let create_result =
+        IronOxide::user_create(&jwt, USER_PASSWORD, &Default::default(), None).await;
     assert!(create_result.is_ok());
 
-    let verify_result = IronOxide::user_verify(&jwt).await;
+    let verify_result = IronOxide::user_verify(&jwt, None).await;
     assert!(verify_result.is_ok());
     verify_result.unwrap().unwrap()
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,5 @@
-use ironoxide::config::IronOxideConfig;
 use ironoxide::{
+    config::IronOxideConfig,
     prelude::*,
     user::{UserCreateOpts, UserResult},
     InitAndRotationCheck,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -6,7 +6,6 @@ use ironoxide::{
 };
 use lazy_static::*;
 use std::{convert::TryInto, default::Default};
-use tokio::time::Duration;
 use uuid::Uuid;
 
 pub const USER_PASSWORD: &str = "foo";
@@ -179,13 +178,9 @@ pub async fn init_sdk_get_init_result(
         users_device_private_key_bytes.try_into().unwrap(),
         users_signing_keys_bytes.try_into().unwrap(),
     );
-    let config = IronOxideConfig {
-        sdk_operation_timeout: Some(Duration::from_secs(3)),
-        ..Default::default()
-    };
     (
         account_id,
-        ironoxide::initialize_check_rotation(&device_init, &config)
+        ironoxide::initialize_check_rotation(&device_init, &Default::default())
             .await
             .unwrap(),
     )

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -108,6 +108,10 @@ pub fn gen_jwt(account_id: Option<&str>) -> (String, String) {
 /// nice error handling with `?` in the tests.
 #[allow(dead_code)]
 pub async fn initialize_sdk() -> Result<IronOxide, IronOxideErr> {
+    init_sdk_with_config(&Default::default()).await
+}
+
+pub async fn init_sdk_with_config(config: &IronOxideConfig) -> Result<IronOxide, IronOxideErr> {
     let account_id: UserId = create_id_all_classes("").try_into()?;
     IronOxide::user_create(
         &gen_jwt(Some(account_id.id())).0,
@@ -121,7 +125,7 @@ pub async fn initialize_sdk() -> Result<IronOxide, IronOxideErr> {
         &Default::default(),
     )
     .await?;
-    ironoxide::initialize(&device.into(), &Default::default()).await
+    ironoxide::initialize(&device.into(), config).await
 }
 
 #[allow(dead_code)]

--- a/tests/document_ops.rs
+++ b/tests/document_ops.rs
@@ -6,8 +6,8 @@ use galvanic_assert::{
     matchers::{collection::contains_in_any_order, eq},
     *,
 };
-use ironoxide::config::IronOxideConfig;
 use ironoxide::{
+    config::IronOxideConfig,
     document::{advanced::*, *},
     group::GroupCreateOpts,
     prelude::*,

--- a/tests/document_ops.rs
+++ b/tests/document_ops.rs
@@ -11,7 +11,7 @@ use ironoxide::{
     document::{advanced::*, *},
     group::GroupCreateOpts,
     prelude::*,
-    IronOxide, SDKOperation,
+    IronOxide, SdkOperation,
 };
 use itertools::EitherOrBoth;
 use std::convert::{TryFrom, TryInto};
@@ -803,7 +803,7 @@ async fn sdk_init_with_timeout() -> Result<(), IronOxideErr> {
     assert_that!(
         &err_result,
         has_structure!(IronOxideErr::OperationTimedOut {
-            operation: eq(SDKOperation::InitializeSdk),
+            operation: eq(SdkOperation::InitializeSdk),
             duration: eq(std::time::Duration::from_millis(10))
         })
     );

--- a/tests/group_ops.rs
+++ b/tests/group_ops.rs
@@ -223,7 +223,9 @@ async fn rotate_all() -> Result<(), IronOxideErr> {
         InitAndRotationCheck::NoRotationNeeded(_) => {
             panic!("both user and groups should need rotation!");
         }
-        InitAndRotationCheck::RotationNeeded(io, rot) => io.rotate_all(&rot, USER_PASSWORD).await?,
+        InitAndRotationCheck::RotationNeeded(io, rot) => {
+            io.rotate_all(&rot, USER_PASSWORD, None).await?
+        }
     };
     assert!(user_result.is_some());
     assert!(group_result.is_some());

--- a/tests/group_ops.rs
+++ b/tests/group_ops.rs
@@ -56,12 +56,14 @@ async fn group_init_and_rotation_check() -> Result<(), IronOxideErr> {
         &gen_jwt(Some(user.id())).0,
         USER_PASSWORD,
         &Default::default(),
+        None,
     )
     .await?;
     let device: DeviceContext = IronOxide::generate_new_device(
         &gen_jwt(Some(user.id())).0,
         USER_PASSWORD,
         &Default::default(),
+        None,
     )
     .await?
     .into();
@@ -177,11 +179,12 @@ async fn rotate_all() -> Result<(), IronOxideErr> {
     use ironoxide::{user::UserCreateOpts, InitAndRotationCheck};
     let account_id: UserId = create_id_all_classes("").try_into()?;
     let jwt = gen_jwt(Some(account_id.id())).0;
-    IronOxide::user_create(&jwt, USER_PASSWORD, &UserCreateOpts::new(true)).await?;
+    IronOxide::user_create(&jwt, USER_PASSWORD, &UserCreateOpts::new(true), None).await?;
     let device: DeviceContext = IronOxide::generate_new_device(
         &gen_jwt(Some(account_id.id())).0,
         USER_PASSWORD,
         &Default::default(),
+        None,
     )
     .await?
     .into();
@@ -227,7 +230,7 @@ async fn rotate_all() -> Result<(), IronOxideErr> {
 
     assert_eq!(group_result.unwrap().len(), 2);
 
-    let user_result = IronOxide::user_verify(&jwt).await?;
+    let user_result = IronOxide::user_verify(&jwt, None).await?;
     assert!(!user_result.unwrap().needs_rotation());
 
     let group1_result = creator_sdk.group_get_metadata(group_create1.id()).await?;

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -10,7 +10,7 @@ use ironoxide::{
     document::DocumentEncryptOpts,
     prelude::*,
     user::{DeviceCreateOpts, UserCreateOpts},
-    SDKOperation,
+    SdkOperation,
 };
 use std::{convert::TryInto, default::Default};
 use uuid::Uuid;
@@ -188,7 +188,7 @@ async fn generate_device_with_timeout() -> Result<(), IronOxideErr> {
     assert_that!(
         &err_result,
         has_structure!(IronOxideErr::OperationTimedOut {
-            operation: eq(SDKOperation::GenerateNewDevice),
+            operation: eq(SdkOperation::GenerateNewDevice),
             duration: eq(std::time::Duration::from_millis(1))
         })
     );

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -1,17 +1,22 @@
 mod common;
 
 use common::{create_id_all_classes, gen_jwt, initialize_sdk};
+use galvanic_assert::{
+    matchers::{collection::contains_in_any_order, eq},
+    *,
+};
+use ironoxide::config::IronOxideConfig;
 use ironoxide::{
     document::DocumentEncryptOpts,
     prelude::*,
     user::{DeviceCreateOpts, UserCreateOpts},
+    SDKOperation,
 };
 use std::{convert::TryInto, default::Default};
 use uuid::Uuid;
-
 #[tokio::test]
 async fn user_verify_non_existing_user() -> Result<(), IronOxideErr> {
-    let option_result = IronOxide::user_verify(&gen_jwt(None).0).await?;
+    let option_result = IronOxide::user_verify(&gen_jwt(None).0, None).await?;
     assert_eq!(true, option_result.is_none());
     Ok(())
 }
@@ -23,10 +28,11 @@ async fn user_verify_existing_user() -> Result<(), IronOxideErr> {
         &gen_jwt(Some(account_id.id())).0,
         "foo",
         &Default::default(),
+        None,
     )
     .await?;
 
-    let result = IronOxide::user_verify(&gen_jwt(Some(account_id.id())).0).await?;
+    let result = IronOxide::user_verify(&gen_jwt(Some(account_id.id())).0, None).await?;
     assert_eq!(true, result.is_some());
     let verify_resp = result.unwrap();
 
@@ -41,10 +47,11 @@ async fn user_verify_after_create_with_needs_rotation() -> Result<(), IronOxideE
         &gen_jwt(Some(account_id.id())).0,
         "foo",
         &UserCreateOpts::new(true),
+        None,
     )
     .await?;
 
-    let result = IronOxide::user_verify(&gen_jwt(Some(account_id.id())).0).await?;
+    let result = IronOxide::user_verify(&gen_jwt(Some(account_id.id())).0, None).await?;
     assert!(result.is_some());
     let verify_resp = result.unwrap();
     assert!(verify_resp.needs_rotation());
@@ -57,12 +64,14 @@ async fn user_create_good_with_devices() -> Result<(), IronOxideErr> {
         &gen_jwt(Some(account_id.id())).0,
         "foo",
         &Default::default(),
+        None,
     )
     .await?;
     let device: DeviceContext = IronOxide::generate_new_device(
         &gen_jwt(Some(account_id.id())).0,
         "foo",
         &DeviceCreateOpts::new(Some("myDevice".try_into()?)),
+        None,
     )
     .await?
     .into();
@@ -132,6 +141,7 @@ async fn user_add_device_after_rotation() -> Result<(), IronOxideErr> {
         &common::gen_jwt(Some(user.id())).0,
         common::USER_PASSWORD,
         &Default::default(),
+        None,
     )
     .await?;
 
@@ -155,8 +165,32 @@ async fn user_create_with_needs_rotation() -> Result<(), IronOxideErr> {
         &gen_jwt(Some(account_id.id())).0,
         common::USER_PASSWORD,
         &UserCreateOpts::new(true),
+        None,
     )
     .await;
     assert!(result?.needs_rotation());
+    Ok(())
+}
+#[tokio::test]
+async fn generate_device_with_timeout() -> Result<(), IronOxideErr> {
+    let result = IronOxide::generate_new_device(
+        common::gen_jwt(None).0.as_str(),
+        "pass",
+        &Default::default(),
+        Some(std::time::Duration::from_millis(1)),
+    )
+    .await;
+
+    assert!(result.is_err());
+    let err_result = result.unwrap_err();
+    dbg!(&err_result);
+    assert_that!(&err_result, is_variant!(IronOxideErr::OperationTimedOut));
+    assert_that!(
+        &err_result,
+        has_structure!(IronOxideErr::OperationTimedOut {
+            operation: eq(SDKOperation::GenerateNewDevice),
+            duration: eq(std::time::Duration::from_millis(1))
+        })
+    );
     Ok(())
 }

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -1,11 +1,7 @@
 mod common;
 
 use common::{create_id_all_classes, gen_jwt, initialize_sdk};
-use galvanic_assert::{
-    matchers::{collection::contains_in_any_order, eq},
-    *,
-};
-use ironoxide::config::IronOxideConfig;
+use galvanic_assert::{matchers::*, *};
 use ironoxide::{
     document::DocumentEncryptOpts,
     prelude::*,


### PR DESCRIPTION
See #19 

* Adds timeouts to all public API methods. Most timeouts use a top-level config set in `IronOxideConfig`. Some special cases allow for passing an optional timeout directly (`rotate_all`, `user_create`, `user_verify`, `generate_new_device`). Timeouts apply to both `IronOxide` and `BlockingIronOxide`
* Configs can now be set on `BlockingIronOxide`. Before, defaults were always used.
* Trying out a "open" struct for all config objects to allow for easier construction and access. If successful, we could use this idea in more in the SDK's public interface.
* Adds dependency on `tokio/rt-threaded` feature flag