### PR TITLE
Add derives for Clone, Debug, Eq, Hash, and PartialEq for public types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
 # Changelog
 
-## 0.19 
+## Unreleased
+
+- [[#119](https://github.com/IronCoreLabs/ironoxide/pull/119)]
+  - Add `Clone`, `Debug`, `Eq`, `Hash`, and `PartialEq` to almost all public structs.
+
+## 0.19
+
 - [[#114]](https://github.com/IronCoreLabs/ironoxide/pull/114)
   - Adds timeouts to all public API methods. Most timeouts use a top-level config set in IronOxideConfig. Some special cases allow for passing an optional timeout directly (rotate_all, user_create, user_verify, generate_new_device). Timeouts apply to both IronOxide and BlockingIronOxide
   - Configs can now be set on BlockingIronOxide. Before, defaults were always used.
   - Trying out an "open" struct for all config objects to allow for easier construction and access
   - Adds dependency on tokio/rt-threaded feature flag
 
-## 0.18 
+## 0.18
 
 - [[#112](https://github.com/IronCoreLabs/ironoxide/pull/112)]
   - Make the default API async

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.20.0
 
 - [[#119](https://github.com/IronCoreLabs/ironoxide/pull/119)]
   - Add `Clone`, `Debug`, `Eq`, `Hash`, and `PartialEq` to almost all public structs.
+  - Depend on a specific commit hash of itertools
 
 ## 0.19.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ## 0.19
 
-- [[#114]](https://github.com/IronCoreLabs/ironoxide/pull/114)
+- [[#114](https://github.com/IronCoreLabs/ironoxide/pull/114)]
   - Adds timeouts to all public API methods. Most timeouts use a top-level config set in IronOxideConfig. Some special cases allow for passing an optional timeout directly (rotate_all, user_create, user_verify, generate_new_device). Timeouts apply to both IronOxide and BlockingIronOxide
   - Configs can now be set on BlockingIronOxide. Before, defaults were always used.
   - Trying out an "open" struct for all config objects to allow for easier construction and access

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rand = "~0.6"
 rand_chacha = "~0.1"
 regex = "~1.3"
 ring = { version= "~0.16", features = ["std"] }
-recrypt = {git = "https://github.com/IronCoreLabs/recrypt-rs", branch = "hash_eq_all_types"}
+recrypt = "~0.10"
 url= "~2.1.0"
 reqwest = {version="~0.10.0", features = ["json"]}
 hex = "~0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironoxide"
-version = "0.19.1"
+version = "0.20.0"
 authors = ["IronCore Labs <info@ironcorelabs.com>"]
 readme = "README.md"
 license = "AGPL-3.0-only"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rand = "~0.6"
 rand_chacha = "~0.1"
 regex = "~1.3"
 ring = { version= "~0.16", features = ["std"] }
-recrypt = "~0.9.2"
+recrypt = {git = "https://github.com/IronCoreLabs/recrypt-rs", branch = "hash_eq_all_types"}
 url= "~2.1.0"
 reqwest = {version="~0.10.0", features = ["json"]}
 hex = "~0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,8 @@ recrypt = {git = "https://github.com/IronCoreLabs/recrypt-rs", branch = "hash_eq
 url= "~2.1.0"
 reqwest = {version="~0.10.0", features = ["json"]}
 hex = "~0.3"
-itertools = "~0.8"
+# itertools 0.8.2++ - remove on next release
+itertools = {git = "https://github.com/rust-itertools/itertools", rev = "c83cc48ffe39b96b7c6797b7b31752e840b373bb"}
 futures = "~0.3.1"
 quick-error = "~1.2"
 lazy_static = "~1.4"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,3 @@
-extern crate protobuf_codegen_pure;
 use std::{
     env,
     fs::File,

--- a/src/crypto/aes.rs
+++ b/src/crypto/aes.rs
@@ -83,7 +83,7 @@ impl EncryptedMasterKey {
         dest
     }
 }
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct AesEncryptedValue {
     aes_iv: [u8; AES_IV_LEN],
     ciphertext: Vec<u8>,

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -21,7 +21,7 @@ use std::hash::{Hash, Hasher};
 pub mod advanced;
 
 /// Optional parameters that can be provided when encrypting a new document.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DocumentEncryptOpts {
     id: Option<DocumentId>,
     name: Option<DocumentName>,
@@ -52,7 +52,7 @@ impl Hash for DocumentEncryptOpts {
 }
 
 /// Explicit users/groups that should have access to decrypt a document.
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct ExplicitGrant {
     grant_to_author: bool,
     grants: Vec<UserOrGroup>,

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -15,40 +15,17 @@ use crate::{
     Result,
 };
 use itertools::{Either, EitherOrBoth, Itertools};
-use std::hash::{Hash, Hasher};
 
 /// Advanced document operations
 pub mod advanced;
 
 /// Optional parameters that can be provided when encrypting a new document.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentEncryptOpts {
     id: Option<DocumentId>,
     name: Option<DocumentName>,
     // at least one user/group must be included either explicitly or via a policy
     grants: EitherOrBoth<ExplicitGrant, PolicyGrant>,
-}
-
-impl Hash for DocumentEncryptOpts {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.id.hash(state);
-        self.name.hash(state);
-        match &self.grants {
-            EitherOrBoth::Left(explicit) => {
-                0.hash(state);
-                explicit.hash(state);
-            }
-            EitherOrBoth::Right(policy) => {
-                1.hash(state);
-                policy.hash(state);
-            }
-            EitherOrBoth::Both(explicit, policy) => {
-                2.hash(state);
-                explicit.hash(state);
-                policy.hash(state);
-            }
-        }
-    }
 }
 
 /// Explicit users/groups that should have access to decrypt a document.

--- a/src/group.rs
+++ b/src/group.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use vec1::Vec1;
 
-#[derive(Clone)]
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 /// Options for group creation.
 pub struct GroupCreateOpts {
     // unique id of a group within a segment. If none, the server will assign an id.

--- a/src/group.rs
+++ b/src/group.rs
@@ -11,8 +11,8 @@ use crate::{
 };
 use vec1::Vec1;
 
-#[derive(Clone, Eq, PartialEq, Hash, Debug)]
 /// Options for group creation.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct GroupCreateOpts {
     // unique id of a group within a segment. If none, the server will assign an id.
     id: Option<GroupId>,

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -46,7 +46,7 @@ const HEADER_META_LENGTH_LENGTH: usize = 2;
 const CURRENT_DOCUMENT_ID_VERSION: u8 = 2;
 
 /// Document ID. Unique within the segment. Must match the regex `^[a-zA-Z0-9_.$#|@/:;=+'-]+$`
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct DocumentId(pub(crate) String);
 impl DocumentId {
     pub fn id(&self) -> &str {
@@ -74,7 +74,7 @@ impl TryFrom<String> for DocumentId {
 }
 
 /// (unencrypted) name of a document. Construct via `try_from(&str)`
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Hash, Eq)]
 pub struct DocumentName(pub(crate) String);
 impl DocumentName {
     pub fn name(&self) -> &String {
@@ -173,7 +173,7 @@ pub enum AssociationType {
 }
 
 /// Represents a User struct which is returned from doc get to show the IDs of users the document is visible to
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct VisibleUser {
     id: UserId,
 }
@@ -184,7 +184,7 @@ impl VisibleUser {
 }
 
 /// Represents a Group struct which is returned from doc get to show the IDs and names of groups the document is visible to
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct VisibleGroup {
     id: GroupId,
     name: Option<GroupName>,
@@ -201,7 +201,7 @@ impl VisibleGroup {
 /// Single document's (abbreviated) metadata. Returned as part of a `DocumentListResult`.
 ///
 /// If you want full metadata for a document, see `DocumentMetadataResult`
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct DocumentListMeta(DocumentListApiResponseItem);
 impl DocumentListMeta {
     pub fn id(&self) -> &DocumentId {
@@ -222,7 +222,7 @@ impl DocumentListMeta {
 }
 
 /// Metadata for each of the documents that the current user has access to decrypt.
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct DocumentListResult {
     result: Vec<DocumentListMeta>,
 }
@@ -233,7 +233,7 @@ impl DocumentListResult {
 }
 
 /// Full metadata for a document.
-#[derive(Clone)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct DocumentMetadataResult(DocumentMetaApiResponse);
 impl DocumentMetadataResult {
     pub fn id(&self) -> &DocumentId {
@@ -273,7 +273,7 @@ impl DocumentMetadataResult {
 /// - `encrypted_data` - Bytes of encrypted document content
 /// - `encrypted_deks` - List of encrypted document encryption keys (EDEK) of users/groups that have been granted access to `encrypted_data`
 /// - `access_errs` - Users and groups that could not be granted access
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct DocumentEncryptUnmanagedResult {
     id: DocumentId,
     encrypted_data: Vec<u8>,
@@ -329,7 +329,7 @@ impl DocumentEncryptUnmanagedResult {
 /// - `encrypted_data` - Bytes of encrypted document content
 /// - `grants` - Users and groups that have access to decrypt the `encrypted_data`
 /// - `access_errs` - Users and groups that could not be granted access
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct DocumentEncryptResult {
     id: DocumentId,
     name: Option<DocumentName>,
@@ -363,7 +363,7 @@ impl DocumentEncryptResult {
     }
 }
 /// Result of decrypting a document. Includes minimal metadata as well as the decrypted bytes.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct DocumentDecryptResult {
     id: DocumentId,
     name: Option<DocumentName>,
@@ -390,7 +390,7 @@ impl DocumentDecryptResult {
 }
 
 /// A failure to edit the access list of a document.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct DocAccessEditErr {
     /// User or group whose access was to be granted/revoked
     pub user_or_group: UserOrGroup,
@@ -409,7 +409,7 @@ impl DocAccessEditErr {
 
 /// Result of granting or revoking access to a document. Both grant and revoke support partial
 /// success.
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct DocumentAccessResult {
     succeeded: Vec<UserOrGroup>,
     failed: Vec<DocAccessEditErr>,
@@ -433,11 +433,11 @@ impl DocumentAccessResult {
         &self.failed
     }
 }
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 struct DecryptedData(Vec<u8>);
 
 /// Result of successful unmanaged decryption
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct DocumentDecryptUnmanagedResult {
     id: DocumentId,
     access_via: UserOrGroup,

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -161,7 +161,7 @@ fn parse_document_parts(
 }
 
 /// Represents the reason a document can be viewed by the requesting user.
-#[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum AssociationType {
     /// User created the document
@@ -173,7 +173,7 @@ pub enum AssociationType {
 }
 
 /// Represents a User struct which is returned from doc get to show the IDs of users the document is visible to
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct VisibleUser {
     id: UserId,
 }
@@ -184,7 +184,7 @@ impl VisibleUser {
 }
 
 /// Represents a Group struct which is returned from doc get to show the IDs and names of groups the document is visible to
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct VisibleGroup {
     id: GroupId,
     name: Option<GroupName>,
@@ -201,7 +201,7 @@ impl VisibleGroup {
 /// Single document's (abbreviated) metadata. Returned as part of a `DocumentListResult`.
 ///
 /// If you want full metadata for a document, see `DocumentMetadataResult`
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentListMeta(DocumentListApiResponseItem);
 impl DocumentListMeta {
     pub fn id(&self) -> &DocumentId {
@@ -222,7 +222,7 @@ impl DocumentListMeta {
 }
 
 /// Metadata for each of the documents that the current user has access to decrypt.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentListResult {
     result: Vec<DocumentListMeta>,
 }
@@ -233,7 +233,7 @@ impl DocumentListResult {
 }
 
 /// Full metadata for a document.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentMetadataResult(DocumentMetaApiResponse);
 impl DocumentMetadataResult {
     pub fn id(&self) -> &DocumentId {
@@ -273,7 +273,7 @@ impl DocumentMetadataResult {
 /// - `encrypted_data` - Bytes of encrypted document content
 /// - `encrypted_deks` - List of encrypted document encryption keys (EDEK) of users/groups that have been granted access to `encrypted_data`
 /// - `access_errs` - Users and groups that could not be granted access
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentEncryptUnmanagedResult {
     id: DocumentId,
     encrypted_data: Vec<u8>,
@@ -329,7 +329,7 @@ impl DocumentEncryptUnmanagedResult {
 /// - `encrypted_data` - Bytes of encrypted document content
 /// - `grants` - Users and groups that have access to decrypt the `encrypted_data`
 /// - `access_errs` - Users and groups that could not be granted access
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentEncryptResult {
     id: DocumentId,
     name: Option<DocumentName>,
@@ -363,7 +363,7 @@ impl DocumentEncryptResult {
     }
 }
 /// Result of decrypting a document. Includes minimal metadata as well as the decrypted bytes.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentDecryptResult {
     id: DocumentId,
     name: Option<DocumentName>,
@@ -390,7 +390,7 @@ impl DocumentDecryptResult {
 }
 
 /// A failure to edit the access list of a document.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocAccessEditErr {
     /// User or group whose access was to be granted/revoked
     pub user_or_group: UserOrGroup,
@@ -409,7 +409,7 @@ impl DocAccessEditErr {
 
 /// Result of granting or revoking access to a document. Both grant and revoke support partial
 /// success.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentAccessResult {
     succeeded: Vec<UserOrGroup>,
     failed: Vec<DocAccessEditErr>,
@@ -437,7 +437,7 @@ impl DocumentAccessResult {
 struct DecryptedData(Vec<u8>);
 
 /// Result of successful unmanaged decryption
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentDecryptUnmanagedResult {
     id: DocumentId,
     access_via: UserOrGroup,
@@ -462,7 +462,7 @@ impl DocumentDecryptUnmanagedResult {
 }
 
 /// Either a user or a group. Allows for containing both.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum UserOrGroup {
     User { id: UserId },
@@ -785,7 +785,7 @@ fn recrypt_document<CR: rand::CryptoRng + rand::RngCore>(
 /// Once decrypted, the DEK serves as a symmetric encryption key.
 ///
 /// It can also be useful to think of an EDEK as representing a "document access grant" to a user/group.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct EncryptedDek {
     grant_to: WithKey<UserOrGroup>,
     encrypted_dek_data: recrypt::api::EncryptedValue,

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -46,7 +46,7 @@ const HEADER_META_LENGTH_LENGTH: usize = 2;
 const CURRENT_DOCUMENT_ID_VERSION: u8 = 2;
 
 /// Document ID. Unique within the segment. Must match the regex `^[a-zA-Z0-9_.$#|@/:;=+'-]+$`
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct DocumentId(pub(crate) String);
 impl DocumentId {
     pub fn id(&self) -> &str {
@@ -92,7 +92,7 @@ impl TryFrom<&str> for DocumentName {
 struct DocHeaderPacked(Vec<u8>);
 
 /// Represents a parsed document header which is decoded from JSON
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 struct DocumentHeader {
     #[serde(rename = "_did_")]
     document_id: DocumentId,
@@ -433,7 +433,7 @@ impl DocumentAccessResult {
         &self.failed
     }
 }
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct DecryptedData(Vec<u8>);
 
 /// Result of successful unmanaged decryption
@@ -859,7 +859,7 @@ impl TryFrom<&EncryptedDek> for EncryptedDekP {
 /// Result of recrypt encryption. Contains the encrypted DEKs and the encrypted (user) data.
 /// `RecryptionResult` is an intermediate value as it cannot be serialized to bytes directly.
 /// To serialize to bytes, first construct an `EncryptedDoc`
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 struct RecryptionResult {
     edeks: Vec<EncryptedDek>,
     encrypted_data: AesEncryptedValue,

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -74,7 +74,7 @@ impl TryFrom<String> for DocumentId {
 }
 
 /// (unencrypted) name of a document. Construct via `try_from(&str)`
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Hash, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct DocumentName(pub(crate) String);
 impl DocumentName {
     pub fn name(&self) -> &String {

--- a/src/internal/document_api/requests.rs
+++ b/src/internal/document_api/requests.rs
@@ -14,19 +14,19 @@ use crate::internal::{
 use chrono::{DateTime, Utc};
 use std::convert::{TryFrom, TryInto};
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Hash, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct Association {
     #[serde(rename = "type")]
     pub typ: AssociationType,
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize)]
 pub struct DocumentVisibility {
     pub users: Vec<VisibleUser>,
     pub groups: Vec<VisibleGroup>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum UserOrGroupWithKey {
     #[serde(rename_all = "camelCase")]
@@ -55,7 +55,7 @@ impl From<UserOrGroupWithKey> for UserOrGroup {
     }
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AccessGrant {
     pub(crate) user_or_group: UserOrGroupWithKey,
@@ -121,7 +121,7 @@ impl From<&AccessGrant> for UserOrGroup {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentMetaApiResponse {
     pub id: DocumentId,
@@ -136,12 +136,12 @@ pub struct DocumentMetaApiResponse {
 pub mod document_list {
     use super::*;
 
-    #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     pub struct DocumentListApiResponse {
         pub result: Vec<DocumentListApiResponseItem>,
     }
 
-    #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Hash, Eq)]
+    #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
     pub struct DocumentListApiResponseItem {
         pub id: DocumentId,
         pub name: Option<DocumentName>,
@@ -198,7 +198,7 @@ pub mod edek_transform {
             .await
     }
 
-    #[derive(Serialize, Debug, Clone, Deserialize, PartialEq)]
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct EdekTransformResponse {
         pub(in crate::internal::document_api) user_or_group: UserOrGroup,
@@ -214,20 +214,20 @@ pub mod document_create {
     };
     use std::convert::TryInto;
 
-    #[derive(Serialize, Debug, Clone, Deserialize, PartialEq)]
+    #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct DocumentCreateValue {
         pub(crate) name: Option<DocumentName>,
         pub(crate) shared_with: Vec<AccessGrant>,
     }
 
-    #[derive(Serialize, Debug, Clone, PartialEq)]
+    #[derive(Clone, Debug, PartialEq, Serialize)]
     pub struct DocumentCreateRequest {
         pub(crate) id: DocumentId,
         pub(crate) value: DocumentCreateValue,
     }
 
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Clone, Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct DocumentCreateResponse {
         pub(crate) id: DocumentId,
@@ -273,7 +273,7 @@ pub mod policy_get {
 
     pub(crate) const SUBSTITUTE_ID_QUERY_PARAM: &str = "substituteId";
 
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Clone, Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct PolicyResponse {
         pub(crate) users_and_groups: Vec<UserOrGroupWithKey>,
@@ -318,7 +318,7 @@ pub mod policy_get {
 pub mod document_update {
     use super::*;
 
-    #[derive(Serialize, Debug, Clone, PartialEq)]
+    #[derive(Clone, Debug, PartialEq, Serialize)]
     struct DocumentUpdateRequest<'a> {
         name: Option<&'a DocumentName>,
     }
@@ -354,20 +354,20 @@ pub mod document_access {
             user_api::UserId,
         };
 
-        #[derive(Deserialize, Debug)]
+        #[derive(Debug, Deserialize)]
         #[serde(rename_all = "camelCase")]
         struct SuccessRes {
             pub(crate) user_or_group: UserOrGroupAccess,
         }
 
-        #[derive(Deserialize, Debug)]
+        #[derive(Debug, Deserialize)]
         #[serde(rename_all = "camelCase")]
         struct FailRes {
             pub(crate) user_or_group: UserOrGroupAccess,
             pub(crate) error_message: String,
         }
 
-        #[derive(Deserialize, Serialize, Debug)]
+        #[derive(Debug, Serialize, Deserialize)]
         #[serde(tag = "type", rename_all = "camelCase")]
         pub enum UserOrGroupAccess {
             User { id: String },
@@ -402,7 +402,7 @@ pub mod document_access {
             }
         }
 
-        #[derive(Deserialize, Debug)]
+        #[derive(Debug, Deserialize)]
         #[serde(rename_all = "camelCase")]
         pub struct DocumentAccessResponse {
             succeeded_ids: Vec<SuccessRes>,
@@ -430,7 +430,7 @@ pub mod document_access {
         }
     }
 
-    #[derive(Serialize, Debug)]
+    #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct DocumentGrantAccessRequest {
         /// Granting user's public key
@@ -438,7 +438,7 @@ pub mod document_access {
         to: Vec<AccessGrant>,
     }
 
-    #[derive(Serialize, Debug)]
+    #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct DocumentRevokeAccessRequest {
         user_or_groups: Vec<UserOrGroupAccess>,

--- a/src/internal/document_api/requests.rs
+++ b/src/internal/document_api/requests.rs
@@ -14,13 +14,13 @@ use crate::internal::{
 use chrono::{DateTime, Utc};
 use std::convert::{TryFrom, TryInto};
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Hash, Eq)]
 pub struct Association {
     #[serde(rename = "type")]
     pub typ: AssociationType,
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DocumentVisibility {
     pub users: Vec<VisibleUser>,
     pub groups: Vec<VisibleGroup>,
@@ -121,7 +121,7 @@ impl From<&AccessGrant> for UserOrGroup {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct DocumentMetaApiResponse {
     pub id: DocumentId,
@@ -141,7 +141,7 @@ pub mod document_list {
         pub result: Vec<DocumentListApiResponseItem>,
     }
 
-    #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+    #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Hash, Eq)]
     pub struct DocumentListApiResponseItem {
         pub id: DocumentId,
         pub name: Option<DocumentName>,

--- a/src/internal/group_api/mod.rs
+++ b/src/internal/group_api/mod.rs
@@ -82,7 +82,7 @@ impl TryFrom<&str> for GroupId {
 }
 
 /// Group's user-assigned name. (non-unique)
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone)]
+#[derive(PartialEq, Debug, Serialize, Deserialize, Clone, Eq, Hash)]
 pub struct GroupName(pub(crate) String);
 impl GroupName {
     pub fn name(&self) -> &String {
@@ -104,7 +104,7 @@ impl TryFrom<&str> for GroupName {
 }
 
 /// List of (abbreviated) groups for which the requesting user is either an admin or member.
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct GroupListResult {
     result: Vec<GroupMetaResult>,
 }
@@ -118,7 +118,7 @@ impl GroupListResult {
     }
 }
 /// Abbreviated group information.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct GroupMetaResult {
     id: GroupId,
     name: Option<GroupName>,
@@ -165,7 +165,7 @@ impl GroupMetaResult {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct GroupCreateResult {
     id: GroupId,
     name: Option<GroupName>,
@@ -227,7 +227,7 @@ impl GroupCreateResult {
     }
 }
 /// Group information.
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct GroupGetResult {
     id: GroupId,
     name: Option<GroupName>,
@@ -293,7 +293,7 @@ impl GroupGetResult {
 }
 
 /// Failure to make the requested change to a group's membership or administrators.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct GroupAccessEditErr {
     user: UserId,
     error: String,
@@ -312,7 +312,7 @@ impl GroupAccessEditErr {
 }
 
 /// Result from requesting changes to a group's membership or administrators. Partial success is supported.
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct GroupAccessEditResult {
     succeeded: Vec<UserId>,
     failed: Vec<GroupAccessEditErr>,
@@ -530,7 +530,7 @@ pub async fn group_create<CR: rand::CryptoRng + rand::RngCore>(
     resp.try_into()
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct GroupUpdatePrivateKeyResult {
     id: GroupId,
     needs_rotation: bool,

--- a/src/internal/group_api/mod.rs
+++ b/src/internal/group_api/mod.rs
@@ -51,7 +51,7 @@ impl GroupCreateOptsStd {
 }
 
 /// Group ID. Unique within a segment. Must match the regex `^[a-zA-Z0-9_.$#|@/:;=+'-]+$`
-#[derive(Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Clone)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct GroupId(pub(crate) String);
 impl GroupId {
     pub fn id(&self) -> &str {
@@ -82,7 +82,7 @@ impl TryFrom<&str> for GroupId {
 }
 
 /// Group's user-assigned name. (non-unique)
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone, Eq, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct GroupName(pub(crate) String);
 impl GroupName {
     pub fn name(&self) -> &String {
@@ -104,7 +104,7 @@ impl TryFrom<&str> for GroupName {
 }
 
 /// List of (abbreviated) groups for which the requesting user is either an admin or member.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct GroupListResult {
     result: Vec<GroupMetaResult>,
 }
@@ -118,7 +118,7 @@ impl GroupListResult {
     }
 }
 /// Abbreviated group information.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct GroupMetaResult {
     id: GroupId,
     name: Option<GroupName>,
@@ -165,7 +165,7 @@ impl GroupMetaResult {
     }
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct GroupCreateResult {
     id: GroupId,
     name: Option<GroupName>,
@@ -227,7 +227,7 @@ impl GroupCreateResult {
     }
 }
 /// Group information.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct GroupGetResult {
     id: GroupId,
     name: Option<GroupName>,
@@ -293,7 +293,7 @@ impl GroupGetResult {
 }
 
 /// Failure to make the requested change to a group's membership or administrators.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct GroupAccessEditErr {
     user: UserId,
     error: String,
@@ -312,7 +312,7 @@ impl GroupAccessEditErr {
 }
 
 /// Result from requesting changes to a group's membership or administrators. Partial success is supported.
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct GroupAccessEditResult {
     succeeded: Vec<UserId>,
     failed: Vec<GroupAccessEditErr>,
@@ -530,7 +530,7 @@ pub async fn group_create<CR: rand::CryptoRng + rand::RngCore>(
     resp.try_into()
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct GroupUpdatePrivateKeyResult {
     id: GroupId,
     needs_rotation: bool,

--- a/src/internal/group_api/requests.rs
+++ b/src/internal/group_api/requests.rs
@@ -18,14 +18,14 @@ use std::{
     convert::{TryFrom, TryInto},
 };
 
-#[derive(Serialize, Deserialize, Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum Permission {
     Member,
     Admin,
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupBasicApiResponse {
     pub(crate) id: GroupId,
@@ -56,7 +56,7 @@ impl TryFrom<GroupBasicApiResponse> for GroupMetaResult {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupGetApiResponse {
     pub(crate) id: GroupId,
@@ -95,7 +95,7 @@ impl TryFrom<GroupGetApiResponse> for GroupGetResult {
     }
 }
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupCreateApiResponse {
     pub(in crate::internal) id: GroupId,
@@ -130,14 +130,14 @@ impl TryFrom<GroupCreateApiResponse> for GroupCreateResult {
     }
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize)]
 pub struct GroupAdmin {
     pub(in crate::internal) user: User,
     #[serde(flatten)]
     pub(in crate::internal) encrypted_msg: EncryptedOnceValue,
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupMember {
     pub(in crate::internal) user_id: UserId,
@@ -145,27 +145,27 @@ pub struct GroupMember {
     pub(in crate::internal) user_master_public_key: PublicKey,
 }
 
-#[derive(Serialize, Debug, PartialEq)]
+#[derive(Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct User {
     pub(in crate::internal) user_id: UserId,
     pub(in crate::internal) user_master_public_key: PublicKey,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SuccessRes {
     pub(crate) user_id: UserId,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FailRes {
     pub(crate) user_id: UserId,
     pub(crate) error_message: String,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GroupUserEditResponse {
     pub(crate) succeeded_ids: Vec<SuccessRes>,
@@ -175,7 +175,7 @@ pub struct GroupUserEditResponse {
 pub mod group_list {
     use super::*;
 
-    #[derive(Deserialize, Debug, Clone)]
+    #[derive(Clone, Debug, Deserialize)]
     pub struct GroupListResponse {
         pub result: Vec<GroupBasicApiResponse>,
     }
@@ -276,14 +276,14 @@ pub mod group_update_private_key {
     use super::*;
     use internal::{group_api::GroupUpdatePrivateKeyResult, rest::json::AugmentationFactor};
 
-    #[derive(Serialize, Debug)]
+    #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct GroupUpdatePrivateKeyRequest {
         admins: Vec<GroupAdmin>,
         augmentation_factor: AugmentationFactor,
     }
 
-    #[derive(Deserialize, PartialEq, Debug)]
+    #[derive(Debug, PartialEq, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct GroupUpdatePrivateKeyResponse {
         group_key_id: u64,
@@ -350,7 +350,7 @@ pub mod group_delete {
 pub mod group_update {
     use super::*;
 
-    #[derive(Serialize, Debug, Clone, PartialEq)]
+    #[derive(Clone, Debug, PartialEq, Serialize)]
     struct GroupUpdateRequest<'a> {
         name: Option<&'a GroupName>,
     }
@@ -446,13 +446,13 @@ pub mod group_add_admin {
 pub mod group_remove_entity {
     use super::*;
 
-    #[derive(Serialize, Debug, Clone, PartialEq)]
+    #[derive(Clone, Debug, PartialEq, Serialize)]
     #[serde(rename_all = "camelCase")]
     struct GroupEntityId<'a> {
         user_id: &'a UserId,
     }
 
-    #[derive(Serialize, Debug, Clone, PartialEq)]
+    #[derive(Clone, Debug, PartialEq, Serialize)]
     struct GroupEntityRemoveRequest<'a> {
         users: Vec<GroupEntityId<'a>>,
     }

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -76,7 +76,7 @@ pub enum RequestErrorCode {
 }
 
 /// Public SDK operations
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum SdkOperation {
     InitializeSdk,
     InitializeSdkCheckRotation,
@@ -348,7 +348,7 @@ impl RequestAuth {
 }
 
 /// Account's device context. Needed to initialize the Sdk with a set of device keys. See `IronOxide.initialize()`
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeviceContext {
     #[serde(flatten)]
@@ -410,8 +410,7 @@ impl From<DeviceAddResult> for DeviceContext {
     }
 }
 
-// Note: Equality is not provided to protect the security of the device private key.
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DeviceAddResult {
     /// The user's given id, which uniquely identifies them inside the segment.
     account_id: UserId,
@@ -497,7 +496,7 @@ impl From<SchnorrSignature> for Vec<u8> {
 
 /// Represents an asymmetric public key that wraps the underlying bytes
 /// of the key.
-#[derive(PartialEq, Debug, Clone, Hash, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct PublicKey(RecryptPublicKey);
 
 impl From<RecryptPublicKey> for PublicKey {
@@ -555,7 +554,7 @@ impl PublicKey {
 
 /// Represents an asymmetric private key that wraps the underlying bytes
 /// of the key.
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct PrivateKey(RecryptPrivateKey);
 impl PrivateKey {
     const BYTES_SIZE: usize = RecryptPrivateKey::ENCODED_SIZE_BYTES;
@@ -671,7 +670,7 @@ impl From<AugmentationFactor> for RecryptPrivateKey {
 }
 
 /// Public/Private asymmetric keypair that is used for decryption/encryption.
-#[derive(Clone)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct KeyPair {
     public_key: PublicKey,
     private_key: PrivateKey,
@@ -695,7 +694,7 @@ impl KeyPair {
 
 /// Signing keypair specific to a device. Used to sign all requests to the IronCore API
 /// endpoints. Needed to create a `DeviceContext`.
-#[derive(Debug, Eq, Clone, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DeviceSigningKeyPair(RecryptSigningKeypair);
 impl From<&DeviceSigningKeyPair> for RecryptSigningKeypair {
     fn from(dsk: &DeviceSigningKeyPair) -> RecryptSigningKeypair {
@@ -715,12 +714,6 @@ impl TryFrom<&[u8]> for DeviceSigningKeyPair {
             .map_err(|e| {
                 IronOxideErr::ValidationError("DeviceSigningKeyPair".to_string(), format!("{}", e))
             })
-    }
-}
-
-impl PartialEq for DeviceSigningKeyPair {
-    fn eq(&self, other: &DeviceSigningKeyPair) -> bool {
-        self.0.bytes().to_vec() == other.0.bytes().to_vec()
     }
 }
 
@@ -809,7 +802,7 @@ impl TryFrom<&str> for Password {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct WithKey<T> {
     pub(crate) id: T,
     pub(crate) public_key: PublicKey,

--- a/src/internal/mod.rs
+++ b/src/internal/mod.rs
@@ -46,7 +46,7 @@ lazy_static! {
     pub static ref OUR_REQUEST: IronCoreRequest = IronCoreRequest::new(URL_STRING.as_str());
 }
 
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum RequestErrorCode {
     UserVerify,
     UserCreate,
@@ -302,7 +302,7 @@ pub mod auth_v2 {
 }
 
 ///Structure that contains all the info needed to make a signed API request from a device.
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RequestAuth {
     ///The user's given id, which uniquely identifies them inside the segment.
@@ -763,7 +763,7 @@ impl DeviceSigningKeyPair {
 ///     "sub" : unique_user_id
 /// });
 ///
-#[derive(Debug, PartialEq, Serialize, Clone)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct Jwt(String);
 impl TryFrom<&str> for Jwt {
     type Error = IronOxideErr;

--- a/src/internal/rest.rs
+++ b/src/internal/rest.rs
@@ -35,7 +35,7 @@ lazy_static! {
     };
 }
 
-#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct ServerError {
     message: String,
     code: u32,
@@ -176,7 +176,7 @@ impl<'a> Authorization<'a> {
 /// We sign over: `/api/1/users?id=abcABC012_.%24%23%7C%40%2F%3A%3B%3D%2B'-`
 ///
 /// Anyone wanting to verify this signature will need to be able to match this exact encoding.
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug)]
 pub struct SignatureUrlString(String);
 
 impl SignatureUrlString {
@@ -297,7 +297,7 @@ impl<'a> HeaderIronCoreRequestSig<'a> {
 }
 
 ///A struct which holds the basic info that will be needed for making requests to an ironcore service. Currently just the base_url.
-#[derive(Debug, Clone, Serialize, Deserialize, Copy, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct IronCoreRequest {
     base_url: &'static str,
 }
@@ -850,7 +850,7 @@ pub mod json {
 
     base64_serde_type!(pub Base64Standard, base64::STANDARD);
 
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash)]
+    #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
     pub struct PublicKey {
         #[serde(with = "Base64Standard")]
         pub x: Vec<u8>,
@@ -879,7 +879,7 @@ pub mod json {
         }
     }
 
-    #[derive(Serialize, Debug, PartialEq)]
+    #[derive(Debug, PartialEq, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct TransformKey {
         ephemeral_public_key: PublicKey,
@@ -909,7 +909,7 @@ pub mod json {
         }
     }
 
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Hash, Eq)]
+    #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct EncryptedOnceValue {
         #[serde(with = "Base64Standard")]
@@ -923,7 +923,7 @@ pub mod json {
         public_signing_key: Vec<u8>,
     }
 
-    #[derive(Serialize, Deserialize, PartialEq, Debug)]
+    #[derive(Debug, PartialEq, Serialize, Deserialize)]
     pub struct AugmentationFactor(#[serde(with = "Base64Standard")] pub Vec<u8>);
 
     impl From<internal::AugmentationFactor> for AugmentationFactor {
@@ -932,7 +932,7 @@ pub mod json {
         }
     }
 
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash)]
+    #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct TransformedEncryptedValue {
         #[serde(flatten)]
@@ -940,7 +940,7 @@ pub mod json {
         transform_blocks: Vec<TransformBlock>,
     }
 
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash)]
+    #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct TransformBlock {
         #[serde(with = "Base64Standard")]

--- a/src/internal/rest.rs
+++ b/src/internal/rest.rs
@@ -297,7 +297,7 @@ impl<'a> HeaderIronCoreRequestSig<'a> {
 }
 
 ///A struct which holds the basic info that will be needed for making requests to an ironcore service. Currently just the base_url.
-#[derive(Debug, Clone, Serialize, Deserialize, Copy)]
+#[derive(Debug, Clone, Serialize, Deserialize, Copy, Eq, PartialEq, Hash)]
 pub struct IronCoreRequest {
     base_url: &'static str,
 }
@@ -850,7 +850,7 @@ pub mod json {
 
     base64_serde_type!(pub Base64Standard, base64::STANDARD);
 
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash)]
     pub struct PublicKey {
         #[serde(with = "Base64Standard")]
         pub x: Vec<u8>,
@@ -909,7 +909,7 @@ pub mod json {
         }
     }
 
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Hash, Eq)]
     #[serde(rename_all = "camelCase")]
     pub struct EncryptedOnceValue {
         #[serde(with = "Base64Standard")]
@@ -932,7 +932,7 @@ pub mod json {
         }
     }
 
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash)]
     #[serde(rename_all = "camelCase")]
     pub struct TransformedEncryptedValue {
         #[serde(flatten)]
@@ -940,7 +940,7 @@ pub mod json {
         transform_blocks: Vec<TransformBlock>,
     }
 
-    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
+    #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Eq, Hash)]
     #[serde(rename_all = "camelCase")]
     pub struct TransformBlock {
         #[serde(with = "Base64Standard")]

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -17,7 +17,7 @@ use std::{
 mod requests;
 
 /// ID of a user. Unique with in a segment. Must match the regex `^[a-zA-Z0-9_.$#|@/:;=+'-]+$`
-#[derive(PartialEq, Debug, Serialize, Deserialize, Clone, Eq, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct UserId(pub(crate) String);
 impl UserId {
     pub fn id(&self) -> &str {
@@ -83,7 +83,7 @@ impl TryFrom<&str> for DeviceName {
 }
 
 /// Keypair for a newly created user
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct UserCreateResult {
     user_public_key: PublicKey,
     // does the private key of this key pair need to be rotated?
@@ -119,7 +119,7 @@ pub struct DeviceAdd {
 }
 
 /// IDs and public key for existing user on verify result
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct UserResult {
     account_id: UserId,
     segment_id: usize,
@@ -145,7 +145,7 @@ impl UserResult {
 }
 
 /// Devices for a user, sorted by the device id
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct UserDeviceListResult {
     result: Vec<UserDevice>,
 }
@@ -160,7 +160,7 @@ impl UserDeviceListResult {
 }
 
 /// Metadata about a user device
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct UserDevice {
     id: DeviceId,
     name: Option<DeviceName>,
@@ -236,7 +236,7 @@ pub async fn user_create<CR: rand::CryptoRng + rand::RngCore>(
     .try_into()
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct EncryptedPrivateKey(Vec<u8>);
 
 impl EncryptedPrivateKey {
@@ -245,7 +245,7 @@ impl EncryptedPrivateKey {
     }
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct UserUpdatePrivateKeyResult {
     user_master_private_key: EncryptedPrivateKey,
     needs_rotation: bool,

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -43,7 +43,7 @@ impl TryFrom<&str> for UserId {
 }
 
 /// Device ID type. Validates that the provided ID is greater than 0
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Eq, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct DeviceId(pub(crate) u64);
 impl DeviceId {
     pub fn id(&self) -> &u64 {

--- a/src/internal/user_api/mod.rs
+++ b/src/internal/user_api/mod.rs
@@ -43,7 +43,7 @@ impl TryFrom<&str> for UserId {
 }
 
 /// Device ID type. Validates that the provided ID is greater than 0
-#[derive(Clone, Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Clone, Serialize, Deserialize, PartialEq, Debug, Eq, Hash)]
 pub struct DeviceId(pub(crate) u64);
 impl DeviceId {
     pub fn id(&self) -> &u64 {
@@ -68,7 +68,7 @@ impl TryFrom<u64> for DeviceId {
 }
 
 /// Device name type. Validates that the provided name isn't an empty string
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct DeviceName(pub(crate) String);
 impl DeviceName {
     pub fn name(&self) -> &String {
@@ -83,7 +83,7 @@ impl TryFrom<&str> for DeviceName {
 }
 
 /// Keypair for a newly created user
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct UserCreateResult {
     user_public_key: PublicKey,
     // does the private key of this key pair need to be rotated?
@@ -119,7 +119,7 @@ pub struct DeviceAdd {
 }
 
 /// IDs and public key for existing user on verify result
-#[derive(Debug)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct UserResult {
     account_id: UserId,
     segment_id: usize,
@@ -144,8 +144,8 @@ impl UserResult {
     }
 }
 
-#[derive(Debug)]
 /// Devices for a user, sorted by the device id
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct UserDeviceListResult {
     result: Vec<UserDevice>,
 }
@@ -159,8 +159,8 @@ impl UserDeviceListResult {
     }
 }
 
-#[derive(Clone, PartialEq, Debug)]
 /// Metadata about a user device
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct UserDevice {
     id: DeviceId,
     name: Option<DeviceName>,
@@ -236,7 +236,7 @@ pub async fn user_create<CR: rand::CryptoRng + rand::RngCore>(
     .try_into()
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct EncryptedPrivateKey(Vec<u8>);
 
 impl EncryptedPrivateKey {
@@ -245,7 +245,7 @@ impl EncryptedPrivateKey {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct UserUpdatePrivateKeyResult {
     user_master_private_key: EncryptedPrivateKey,
     needs_rotation: bool,

--- a/src/internal/user_api/requests.rs
+++ b/src/internal/user_api/requests.rs
@@ -18,7 +18,7 @@ use chrono::{DateTime, Utc};
 use std::convert::TryFrom;
 
 use crate::internal::auth_v2::AuthV2Builder;
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct EncryptedPrivateKey(#[serde(with = "Base64Standard")] pub Vec<u8>);
 
 impl From<EncryptedMasterKey> for EncryptedPrivateKey {
@@ -47,7 +47,7 @@ pub mod user_verify {
 
     use super::*;
 
-    #[derive(Deserialize, PartialEq, Debug)]
+    #[derive(Debug, PartialEq, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct UserVerifyResponse {
         pub(crate) id: String,
@@ -133,7 +133,7 @@ pub mod user_get {
     use super::*;
     use crate::internal::group_api::GroupId;
 
-    #[derive(Deserialize, PartialEq, Debug)]
+    #[derive(Debug, PartialEq, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct CurrentUserResponse {
         pub(in crate::internal) current_key_id: u64,
@@ -162,14 +162,14 @@ pub mod user_update_private_key {
     use super::*;
     use internal::{rest::json::AugmentationFactor, user_api::UserUpdatePrivateKeyResult};
 
-    #[derive(Serialize, Debug)]
+    #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct UserUpdatePrivateKey {
         user_private_key: EncryptedPrivateKey,
         augmentation_factor: AugmentationFactor,
     }
 
-    #[derive(Deserialize, PartialEq, Debug)]
+    #[derive(Debug, PartialEq, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct UserUpdatePrivateKeyResponse {
         current_key_id: u64,
@@ -217,7 +217,7 @@ pub mod user_create {
 
     use super::*;
 
-    #[derive(Deserialize, PartialEq, Debug)]
+    #[derive(Debug, PartialEq, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct UserCreateResponse {
         id: String,
@@ -228,7 +228,7 @@ pub mod user_create {
         needs_rotation: bool,
     }
 
-    #[derive(Serialize, Debug)]
+    #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
     struct UserCreateReq {
         user_public_key: PublicKey,
@@ -312,7 +312,7 @@ pub mod device_add {
 
     use super::*;
 
-    #[derive(Serialize, Debug)]
+    #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct DeviceAddReq {
         pub timestamp: u64,
@@ -322,14 +322,14 @@ pub mod device_add {
         pub user_public_key: PublicKey,
     }
 
-    #[derive(Serialize, Debug)]
+    #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
     pub struct Device {
         pub transform_key: TransformKey,
         pub name: Option<DeviceName>,
     }
 
-    #[derive(Deserialize, Debug)]
+    #[derive(Debug, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct DeviceAddResponse {
         #[serde(rename = "id")]
@@ -373,7 +373,7 @@ pub mod device_list {
 
     use super::*;
 
-    #[derive(Deserialize, PartialEq, Debug)]
+    #[derive(Debug, PartialEq, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct DeviceListItem {
         #[serde(rename = "id")]
@@ -384,7 +384,7 @@ pub mod device_list {
         is_current_device: bool,
     }
 
-    #[derive(Deserialize, PartialEq, Debug)]
+    #[derive(Debug, PartialEq, Deserialize)]
     pub struct DeviceListResponse {
         pub(in crate::internal) result: Vec<DeviceListItem>,
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,12 +99,7 @@ use rand::{
 };
 use rand_chacha::ChaChaCore;
 use recrypt::api::{Ed25519, RandomBytes, Recrypt, Sha256};
-use std::{
-    convert::TryInto,
-    fmt,
-    hash::{Hash, Hasher},
-    sync::Mutex,
-};
+use std::{convert::TryInto, fmt, sync::Mutex};
 use vec1::Vec1;
 
 /// Result of an Sdk operation
@@ -210,7 +205,7 @@ impl<T> InitAndRotationCheck<T> {
 const BYTES_BEFORE_RESEEDING: u64 = 1024 * 1024;
 
 /// Provides soft rotation capabilities for user and group keys
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct PrivateKeyRotationCheckResult {
     pub rotations_needed: EitherOrBoth<UserId, Vec1<GroupId>>,
 }
@@ -227,26 +222,6 @@ impl PrivateKeyRotationCheckResult {
         match &self.rotations_needed {
             EitherOrBoth::Right(groups) | EitherOrBoth::Both(_, groups) => Some(groups),
             _ => None,
-        }
-    }
-}
-
-impl Hash for PrivateKeyRotationCheckResult {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        match &self.rotations_needed {
-            EitherOrBoth::Left(user) => {
-                0.hash(state);
-                user.hash(state);
-            }
-            EitherOrBoth::Right(group) => {
-                1.hash(state);
-                group.hash(state);
-            }
-            EitherOrBoth::Both(user, group) => {
-                2.hash(state);
-                user.hash(state);
-                group.hash(state);
-            }
         }
     }
 }

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -85,7 +85,7 @@ use std::convert::TryFrom;
 /// rule may generate any number of users/groups.
 ///
 /// `substitute_user` replaces `%USER%` in a matched policy rule.
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct PolicyGrant {
     category: Option<Category>,
     sensitivity: Option<Sensitivity>,
@@ -137,7 +137,7 @@ impl Default for PolicyGrant {
 
 macro_rules! policy_field {
     ($t: ident, $l: literal) => {
-        #[derive(Debug, PartialEq, Eq, Hash, Clone)]
+        #[derive(Clone, Debug, Eq, Hash, PartialEq)]
         pub struct $t(pub(crate) String);
 
         impl TryFrom<&str> for $t {

--- a/src/user.rs
+++ b/src/user.rs
@@ -14,7 +14,7 @@ use recrypt::api::Recrypt;
 use std::{collections::HashMap, convert::TryInto};
 
 /// Optional parameters for creating a new device instance.
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DeviceCreateOpts {
     device_name: Option<DeviceName>,
 }
@@ -31,7 +31,7 @@ impl Default for DeviceCreateOpts {
 }
 
 /// Options that can be specified at when calling [`user_create`](trait.UserOps.html#tymethod.user_create).
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct UserCreateOpts {
     // see docs on `new`
     needs_rotation: bool,

--- a/src/user.rs
+++ b/src/user.rs
@@ -14,7 +14,7 @@ use recrypt::api::Recrypt;
 use std::{collections::HashMap, convert::TryInto};
 
 /// Optional parameters for creating a new device instance.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct DeviceCreateOpts {
     device_name: Option<DeviceName>,
 }
@@ -31,6 +31,7 @@ impl Default for DeviceCreateOpts {
 }
 
 /// Options that can be specified at when calling [`user_create`](trait.UserOps.html#tymethod.user_create).
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 pub struct UserCreateOpts {
     // see docs on `new`
     needs_rotation: bool,


### PR DESCRIPTION
This makes sure that Clone, Debug, Eq, Hash, and PartialEq are on all of our public types. 

Exceptions:
- IronOxide/BlockingIronOxide only have Debug, as parts of them like recrypt stop them from having others. 
- build.rs-generated structs like `ironoxide::proto::transform::PublicKey` only have Clone and PartialEq. I looked into finding a way to make it add others with no success. The full list is `EncryptedDekData`, `EncryptedDeks`, `PublicKey`, `UserOrGroup`, and the enum `UserOrGroup_oneof_userOrGroupId`.

TODO:
- [x] Depend on released recrypt-rs
- [x] Changelog