### PR TITLE
Add clear_policy_cache() to BlockingIronOxide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## Unreleased
+## 0.19.1
 
 - [[#120](https://github.com/IronCoreLabs/ironoxide/pull/120)]
   - Adds `clear_policy_cache()` to `BlockingIronOxide`.
 
-## 0.19
+## 0.19.0
 
 - [[#114](https://github.com/IronCoreLabs/ironoxide/pull/114)]
   - Adds timeouts to all public API methods. Most timeouts use a top-level config set in IronOxideConfig. Some special cases allow for passing an optional timeout directly (rotate_all, user_create, user_verify, generate_new_device). Timeouts apply to both IronOxide and BlockingIronOxide
@@ -13,7 +13,7 @@
   - Trying out an "open" struct for all config objects to allow for easier construction and access
   - Adds dependency on tokio/rt-threaded feature flag
 
-## 0.18
+## 0.18.0
 
 - [[#112](https://github.com/IronCoreLabs/ironoxide/pull/112)]
   - Make the default API async

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,19 @@
 # Changelog
 
-## 0.19 
-- [[#114]](https://github.com/IronCoreLabs/ironoxide/pull/114)
+## Unreleased
+
+- [[#120](https://github.com/IronCoreLabs/ironoxide/pull/120)]
+  - Adds `clear_policy_cache()` to `BlockingIronOxide`.
+
+## 0.19
+
+- [[#114](https://github.com/IronCoreLabs/ironoxide/pull/114)]
   - Adds timeouts to all public API methods. Most timeouts use a top-level config set in IronOxideConfig. Some special cases allow for passing an optional timeout directly (rotate_all, user_create, user_verify, generate_new_device). Timeouts apply to both IronOxide and BlockingIronOxide
   - Configs can now be set on BlockingIronOxide. Before, defaults were always used.
   - Trying out an "open" struct for all config objects to allow for easier construction and access
   - Adds dependency on tokio/rt-threaded feature flag
 
-## 0.18 
+## 0.18
 
 - [[#112](https://github.com/IronCoreLabs/ironoxide/pull/112)]
   - Make the default API async

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.19.1
 
 - [[#120](https://github.com/IronCoreLabs/ironoxide/pull/120)]
-  - Adds `clear_policy_cache()` to `BlockingIronOxide`.
+  - Add `clear_policy_cache()` to `BlockingIronOxide`.
 
 ## 0.19.0
 

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -50,6 +50,13 @@ impl BlockingIronOxide {
         &self.ironoxide.device
     }
 
+    /// Clears all entries from the policy cache.
+    /// # Returns
+    /// Number of entries cleared from the cache
+    pub fn clear_policy_cache(&self) -> usize {
+        self.ironoxide.clear_policy_cache()
+    }
+
     /// See [ironoxide::IronOxide::rotate_all()](../struct.IronOxide.html#method.rotate_all)
     pub fn rotate_all(
         &self,

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -50,9 +50,7 @@ impl BlockingIronOxide {
         &self.ironoxide.device
     }
 
-    /// Clears all entries from the policy cache.
-    /// # Returns
-    /// Number of entries cleared from the cache
+    /// See [ironoxide::IronOxide::clear_policy_cache()](../struct.IronOxide.html#method.clear_policy_cache)
     pub fn clear_policy_cache(&self) -> usize {
         self.ironoxide.clear_policy_cache()
     }


### PR DESCRIPTION
Add function to BlockingIronOxide to clear policy cache. Simply calls `clear_policy_cache()` on its internal IronOxide.