### PR TITLE
Clean up GroupUpdatePrivateKeyResponse.into()

### DIFF
--- a/src/internal/group_api/mod.rs
+++ b/src/internal/group_api/mod.rs
@@ -638,7 +638,7 @@ pub async fn group_rotate_private_key<CR: rand::CryptoRng + rand::RngCore>(
         aug_factor,
     )
     .await
-    .map(|resp| (resp, group_id.to_owned()).into())
+    .map(|resp| resp.into())
 }
 
 /// Get the metadata for a group given its ID

--- a/src/internal/group_api/requests.rs
+++ b/src/internal/group_api/requests.rs
@@ -287,15 +287,16 @@ pub mod group_update_private_key {
     #[serde(rename_all = "camelCase")]
     pub struct GroupUpdatePrivateKeyResponse {
         group_key_id: u64,
+        group_id: GroupId,
         needs_rotation: bool,
     }
 
-    impl From<(GroupUpdatePrivateKeyResponse, GroupId)> for GroupUpdatePrivateKeyResult {
-        fn from(resp_and_id: (GroupUpdatePrivateKeyResponse, GroupId)) -> Self {
+    impl From<GroupUpdatePrivateKeyResponse> for GroupUpdatePrivateKeyResult {
+        fn from(resp: GroupUpdatePrivateKeyResponse) -> Self {
             // don't expose the current_key_id to the outside world until we need to
             GroupUpdatePrivateKeyResult {
-                id: resp_and_id.1,
-                needs_rotation: resp_and_id.0.needs_rotation,
+                id: resp.group_id,
+                needs_rotation: resp.needs_rotation,
             }
         }
     }


### PR DESCRIPTION
Now that rotating the group's private key returns the group ID (currently only in dev), we can clean up our `From` impl to create a `GroupUpdatePrivateKeyResult` more cleanly.