### PR TITLE
Remove default features from publicsuffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## 0.21.1 (unreleased)
+
+- [[#138](https://github.com/IronCoreLabs/ironoxide/pull/138)]
+  - Remove `publicsuffix` default features (openssl-sys) 
 - [[#129](https://github.com/IronCoreLabs/ironoxide/pull/129)] 
   - Improve error message for SDK initialization failure
 - [[#132](https://github.com/IronCoreLabs/ironoxide/pull/132)]  

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ base64-serde = "~0.3.1"
 bytes = "~0.5"
 serde = "~1.0"
 serde_json = "~1.0"
-publicsuffix = "~1.5.4"
+# default features force a dependency on openssl-sys, which we want to avoid for embedded applications
+publicsuffix = { version="~1.5.4", default-features = false}
 serde_derive = "~1.0"
 rand = "~0.7"
 rand_chacha = "~0.2.2"


### PR DESCRIPTION
There is no downside here since we don't use any of the default features.

The motivation was that by default `publicsuffix` depends on `openssl-sys` for some functionality that we don't use. This causes problems in embedded environments that don't have openssl.

Now if you you depend `tls-rustls` in ironoxide, openssl is not needed at all compile time or runtime. It is still needed for integration tests because of our dependency on `frank_jwt`