### PR TITLE
Update DocumentOps docs

### DIFF
--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -53,19 +53,19 @@ impl BlockingIronOxide {
         &self.ironoxide.device
     }
 
-    /// See [ironoxide::IronOxide::clear_policy_cache()](../struct.IronOxide.html#method.clear_policy_cache)
+    /// See [ironoxide::IronOxide::clear_policy_cache](../struct.IronOxide.html#method.clear_policy_cache)
     pub fn clear_policy_cache(&self) -> usize {
         self.ironoxide.clear_policy_cache()
     }
 
-    /// See [ironoxide::IronOxide::create_blind_index()](../struct.IronOxide.html#method.create_blind_index)
+    /// See [ironoxide::IronOxide::create_blind_index](../struct.IronOxide.html#method.create_blind_index)
     #[cfg(feature = "beta")]
     pub fn create_blind_index(&self, group_id: &GroupId) -> Result<EncryptedBlindIndexSalt> {
         self.runtime
             .enter(|| block_on(self.ironoxide.create_blind_index(group_id)))
     }
 
-    /// See [ironoxide::IronOxide::rotate_all()](../struct.IronOxide.html#method.rotate_all)
+    /// See [ironoxide::IronOxide::rotate_all](../struct.IronOxide.html#method.rotate_all)
     pub fn rotate_all(
         &self,
         rotations: &PrivateKeyRotationCheckResult,
@@ -79,22 +79,22 @@ impl BlockingIronOxide {
             .enter(|| block_on(self.ironoxide.rotate_all(rotations, password, timeout)))
     }
 
-    /// See [ironoxide::document::DocumentOps::document_list()](trait.DocumentOps.html#tymethod.document_list)
+    /// See [ironoxide::document::DocumentOps::document_list](trait.DocumentOps.html#tymethod.document_list)
     pub fn document_list(&self) -> Result<DocumentListResult> {
         self.runtime
             .enter(|| block_on(self.ironoxide.document_list()))
     }
-    /// See [ironoxide::document::DocumentOps::document_get_metadata()](trait.DocumentOps.html#tymethod.document_get_metadata)
+    /// See [ironoxide::document::DocumentOps::document_get_metadata](trait.DocumentOps.html#tymethod.document_get_metadata)
     pub fn document_get_metadata(&self, id: &DocumentId) -> Result<DocumentMetadataResult> {
         self.runtime
             .enter(|| block_on(self.ironoxide.document_get_metadata(id)))
     }
-    /// See [ironoxide::document::DocumentOps::document_get_id_from_bytes()](trait.DocumentOps.html#tymethod.document_get_id_from_bytes)
+    /// See [ironoxide::document::DocumentOps::document_get_id_from_bytes](trait.DocumentOps.html#tymethod.document_get_id_from_bytes)
     pub fn document_get_id_from_bytes(&self, encrypted_document: &[u8]) -> Result<DocumentId> {
         self.ironoxide
             .document_get_id_from_bytes(encrypted_document)
     }
-    /// See [ironoxide::document::DocumentOps::document_encrypt()](trait.DocumentOps.html#tymethod.document_encrypt)
+    /// See [ironoxide::document::DocumentOps::document_encrypt](trait.DocumentOps.html#tymethod.document_encrypt)
     pub fn document_encrypt(
         &self,
         document_data: &[u8],
@@ -103,7 +103,7 @@ impl BlockingIronOxide {
         self.runtime
             .enter(|| block_on(self.ironoxide.document_encrypt(document_data, encrypt_opts)))
     }
-    /// See [ironoxide::document::DocumentOps::document_update_bytes()](trait.DocumentOps.html#tymethod.document_update_bytes)
+    /// See [ironoxide::document::DocumentOps::document_update_bytes](trait.DocumentOps.html#tymethod.document_update_bytes)
     pub fn document_update_bytes(
         &self,
         id: &DocumentId,
@@ -112,12 +112,12 @@ impl BlockingIronOxide {
         self.runtime
             .enter(|| block_on(self.ironoxide.document_update_bytes(id, new_document_data)))
     }
-    /// See [ironoxide::document::DocumentOps::document_decrypt()](trait.DocumentOps.html#tymethod.document_decrypt)
+    /// See [ironoxide::document::DocumentOps::document_decrypt](trait.DocumentOps.html#tymethod.document_decrypt)
     pub fn document_decrypt(&self, encrypted_document: &[u8]) -> Result<DocumentDecryptResult> {
         self.runtime
             .enter(|| block_on(self.ironoxide.document_decrypt(encrypted_document)))
     }
-    /// See [ironoxide::document::DocumentOps::document_update_name()](trait.DocumentOps.html#tymethod.document_update_name)
+    /// See [ironoxide::document::DocumentOps::document_update_name](trait.DocumentOps.html#tymethod.document_update_name)
     pub fn document_update_name(
         &self,
         id: &DocumentId,
@@ -126,7 +126,7 @@ impl BlockingIronOxide {
         self.runtime
             .enter(|| block_on(self.ironoxide.document_update_name(id, name)))
     }
-    /// See [ironoxide::document::DocumentOps::document_grant_access()](trait.DocumentOps.html#tymethod.document_grant_access)
+    /// See [ironoxide::document::DocumentOps::document_grant_access](trait.DocumentOps.html#tymethod.document_grant_access)
     pub fn document_grant_access(
         &self,
         id: &DocumentId,
@@ -135,7 +135,7 @@ impl BlockingIronOxide {
         self.runtime
             .enter(|| block_on(self.ironoxide.document_grant_access(id, grant_list)))
     }
-    /// See [ironoxide::document::DocumentOps::document_revoke_access()](trait.DocumentOps.html#tymethod.document_revoke_access)
+    /// See [ironoxide::document::DocumentOps::document_revoke_access](trait.DocumentOps.html#tymethod.document_revoke_access)
     pub fn document_revoke_access(
         &self,
         id: &DocumentId,
@@ -144,7 +144,7 @@ impl BlockingIronOxide {
         self.runtime
             .enter(|| block_on(self.ironoxide.document_revoke_access(id, revoke_list)))
     }
-    /// See [ironoxide::document::advanced::DocumentAdvancedOps::document_encrypt_unmanaged()](trait.DocumentAdvancedOps.html#tymethod.document_encrypt_unmanaged)
+    /// See [ironoxide::document::advanced::DocumentAdvancedOps::document_encrypt_unmanaged](trait.DocumentAdvancedOps.html#tymethod.document_encrypt_unmanaged)
     pub fn document_encrypt_unmanaged(
         &self,
         data: &[u8],
@@ -157,7 +157,7 @@ impl BlockingIronOxide {
             )
         })
     }
-    /// See [ironoxide::document::advanced::DocumentAdvancedOps::document_decrypt_unmanaged()](trait.DocumentAdvancedOps.html#tymethod.document_decrypt_unmanaged)
+    /// See [ironoxide::document::advanced::DocumentAdvancedOps::document_decrypt_unmanaged](trait.DocumentAdvancedOps.html#tymethod.document_decrypt_unmanaged)
     pub fn document_decrypt_unmanaged(
         &self,
         encrypted_data: &[u8],
@@ -170,26 +170,26 @@ impl BlockingIronOxide {
             )
         })
     }
-    /// See [ironoxide::group::GroupOps::group_list()](trait.GroupOps.html#tymethod.group_list)
+    /// See [ironoxide::group::GroupOps::group_list](trait.GroupOps.html#tymethod.group_list)
     pub fn group_list(&self) -> Result<GroupListResult> {
         self.runtime.enter(|| block_on(self.ironoxide.group_list()))
     }
-    /// See [ironoxide::group::GroupOps::group_create()](trait.GroupOps.html#tymethod.group_create)
+    /// See [ironoxide::group::GroupOps::group_create](trait.GroupOps.html#tymethod.group_create)
     pub fn group_create(&self, opts: &GroupCreateOpts) -> Result<GroupCreateResult> {
         self.runtime
             .enter(|| block_on(self.ironoxide.group_create(opts)))
     }
-    /// See [ironoxide::group::GroupOps::group_get_metadata()](trait.GroupOps.html#tymethod.group_get_metadata)
+    /// See [ironoxide::group::GroupOps::group_get_metadata](trait.GroupOps.html#tymethod.group_get_metadata)
     pub fn group_get_metadata(&self, id: &GroupId) -> Result<GroupGetResult> {
         self.runtime
             .enter(|| block_on(self.ironoxide.group_get_metadata(id)))
     }
-    /// See [ironoxide::group::GroupOps::group_delete()](trait.GroupOps.html#tymethod.group_delete)
+    /// See [ironoxide::group::GroupOps::group_delete](trait.GroupOps.html#tymethod.group_delete)
     pub fn group_delete(&self, id: &GroupId) -> Result<GroupId> {
         self.runtime
             .enter(|| block_on(self.ironoxide.group_delete(id)))
     }
-    /// See [ironoxide::group::GroupOps::group_update_name()](trait.GroupOps.html#tymethod.group_update_name)
+    /// See [ironoxide::group::GroupOps::group_update_name](trait.GroupOps.html#tymethod.group_update_name)
     pub fn group_update_name(
         &self,
         id: &GroupId,
@@ -198,7 +198,7 @@ impl BlockingIronOxide {
         self.runtime
             .enter(|| block_on(self.ironoxide.group_update_name(id, name)))
     }
-    /// See [ironoxide::group::GroupOps::group_add_members()](trait.GroupOps.html#tymethod.group_add_members)
+    /// See [ironoxide::group::GroupOps::group_add_members](trait.GroupOps.html#tymethod.group_add_members)
     pub fn group_add_members(
         &self,
         id: &GroupId,
@@ -207,7 +207,7 @@ impl BlockingIronOxide {
         self.runtime
             .enter(|| block_on(self.ironoxide.group_add_members(id, grant_list)))
     }
-    /// See [ironoxide::group::GroupOps::group_remove_members()](trait.GroupOps.html#tymethod.group_remove_members)
+    /// See [ironoxide::group::GroupOps::group_remove_members](trait.GroupOps.html#tymethod.group_remove_members)
     pub fn group_remove_members(
         &self,
         id: &GroupId,
@@ -216,7 +216,7 @@ impl BlockingIronOxide {
         self.runtime
             .enter(|| block_on(self.ironoxide.group_remove_members(id, revoke_list)))
     }
-    /// See [ironoxide::group::GroupOps::group_add_admins()](trait.GroupOps.html#tymethod.group_add_admins)
+    /// See [ironoxide::group::GroupOps::group_add_admins](trait.GroupOps.html#tymethod.group_add_admins)
     pub fn group_add_admins(
         &self,
         id: &GroupId,
@@ -225,7 +225,7 @@ impl BlockingIronOxide {
         self.runtime
             .enter(|| block_on(self.ironoxide.group_add_admins(id, users)))
     }
-    /// See [ironoxide::group::GroupOps::group_remove_admins()](trait.GroupOps.html#tymethod.group_remove_admins)
+    /// See [ironoxide::group::GroupOps::group_remove_admins](trait.GroupOps.html#tymethod.group_remove_admins)
     pub fn group_remove_admins(
         &self,
         id: &GroupId,
@@ -234,12 +234,12 @@ impl BlockingIronOxide {
         self.runtime
             .enter(|| block_on(self.ironoxide.group_remove_admins(id, revoke_list)))
     }
-    /// See [ironoxide::group::GroupOps::group_rotate_private_key()](trait.GroupOps.html#tymethod.group_rotate_private_key)
+    /// See [ironoxide::group::GroupOps::group_rotate_private_key](trait.GroupOps.html#tymethod.group_rotate_private_key)
     pub fn group_rotate_private_key(&self, id: &GroupId) -> Result<GroupUpdatePrivateKeyResult> {
         self.runtime
             .enter(|| block_on(self.ironoxide.group_rotate_private_key(id)))
     }
-    /// See [ironoxide::user::UserOps::user_create()](trait.UserOps.html#tymethod.user_create)
+    /// See [ironoxide::user::UserOps::user_create](trait.UserOps.html#tymethod.user_create)
     pub fn user_create(
         jwt: &str,
         password: &str,
@@ -256,12 +256,12 @@ impl BlockingIronOxide {
             ))
         })
     }
-    /// See [ironoxide::user::UserOps::user_list_devices()](trait.UserOps.html#tymethod.user_list_devices)
+    /// See [ironoxide::user::UserOps::user_list_devices](trait.UserOps.html#tymethod.user_list_devices)
     pub fn user_list_devices(&self) -> Result<UserDeviceListResult> {
         self.runtime
             .enter(|| block_on(self.ironoxide.user_list_devices()))
     }
-    /// See [ironoxide::user::UserOps::generate_new_device()](trait.UserOps.html#tymethod.generate_new_device)
+    /// See [ironoxide::user::UserOps::generate_new_device](trait.UserOps.html#tymethod.generate_new_device)
     pub fn generate_new_device(
         jwt: &str,
         password: &str,
@@ -278,12 +278,12 @@ impl BlockingIronOxide {
             ))
         })
     }
-    /// See [ironoxide::user::UserOps::user_delete_device()](trait.UserOps.html#tymethod.user_delete_device)
+    /// See [ironoxide::user::UserOps::user_delete_device](trait.UserOps.html#tymethod.user_delete_device)
     pub fn user_delete_device(&self, device_id: Option<&DeviceId>) -> Result<DeviceId> {
         self.runtime
             .enter(|| block_on(self.ironoxide.user_delete_device(device_id)))
     }
-    /// See [ironoxide::user::UserOps::user_verify()](trait.UserOps.html#tymethod.user_verify)
+    /// See [ironoxide::user::UserOps::user_verify](trait.UserOps.html#tymethod.user_verify)
     pub fn user_verify(
         jwt: &str,
         timeout: Option<std::time::Duration>,
@@ -291,12 +291,12 @@ impl BlockingIronOxide {
         let rt = create_runtime();
         rt.enter(|| block_on(IronOxide::user_verify(jwt, timeout)))
     }
-    /// See [ironoxide::user::UserOps::user_get_public_key()](trait.UserOps.html#tymethod.user_get_public_key)
+    /// See [ironoxide::user::UserOps::user_get_public_key](trait.UserOps.html#tymethod.user_get_public_key)
     pub fn user_get_public_key(&self, users: &[UserId]) -> Result<HashMap<UserId, PublicKey>> {
         self.runtime
             .enter(|| block_on(self.ironoxide.user_get_public_key(users)))
     }
-    /// See [ironoxide::user::UserOps::user_rotate_private_key()](trait.UserOps.html#tymethod.user_rotate_private_key)
+    /// See [ironoxide::user::UserOps::user_rotate_private_key](trait.UserOps.html#tymethod.user_rotate_private_key)
     pub fn user_rotate_private_key(&self, password: &str) -> Result<UserUpdatePrivateKeyResult> {
         self.runtime
             .enter(|| block_on(self.ironoxide.user_rotate_private_key(password)))

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -298,9 +298,9 @@ pub trait DocumentOps {
     /// `grant_list` - List of users and groups to grant access to.
     ///
     /// # Errors
-    /// Fails only if the calling user does not have access to the document. If the response is an `Ok`, then the resulting
-    /// `DocumentAccessResult` will indicate which grants succeeded and which failed, and it will provide explanations for
-    /// each failure.
+    /// This operation supports partial success. If the request succeeds, then the resulting
+    /// `DocumentAccessResult` will indicate which grants succeeded and which failed, and it
+    /// will provide an explanation for each failure.
     ///
     /// # Examples
     /// ```
@@ -332,9 +332,9 @@ pub trait DocumentOps {
     /// `revoke_list` - List of users and groups to revoke access from.
     ///
     /// # Errors
-    /// Fails only if the calling user does not have access to the document. If the response is an `Ok`, then the resulting
-    /// `DocumentAccessResult` will indicate which revocations succeeded and which failed, and it will provide explanations for
-    /// each failure.
+    /// This operation supports partial success. If the request succeeds, then the resulting
+    /// `DocumentAccessResult` will indicate which revocations succeeded and which failed, and it
+    /// will provide an explanation for each failure.
     ///
     /// # Examples
     /// ```

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -19,7 +19,7 @@ use itertools::{Either, EitherOrBoth, Itertools};
 /// Advanced document operations
 pub mod advanced;
 
-/// Explicit list of users and groups that should have access to decrypt a document.
+/// List of users and groups that should have access to decrypt a document.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct ExplicitGrant {
     grant_to_author: bool,
@@ -203,13 +203,13 @@ pub trait DocumentOps {
     /// # use ironoxide::prelude::*;
     /// # let sdk: IronOxide = unimplemented!();
     /// # let document_id: DocumentId = unimplemented!();
-    /// let document_data = sdk.document_get_metadata(&document_id).await?;
+    /// let document_meta = sdk.document_get_metadata(&document_id).await?;
     /// # Ok(())
     /// # }
     /// ```
     async fn document_get_metadata(&self, id: &DocumentId) -> Result<DocumentMetadataResult>;
 
-    /// Returns the document ID from the bytes of an IronCore encrypted document.
+    /// Returns the document ID from the bytes of an encrypted document.
     ///
     /// This is the same ID returned by `DocumentEncryptResult.id()`.
     ///
@@ -217,7 +217,7 @@ pub trait DocumentOps {
     /// - `encrypted_document` - Bytes of the encrypted document
     ///
     /// # Errors
-    /// Fails if the provided encrypted bytes have no header.
+    /// Fails if the provided bytes are not an encrypted document or have no header.
     ///
     /// # Examples
     /// ```

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -19,16 +19,7 @@ use itertools::{Either, EitherOrBoth, Itertools};
 /// Advanced document operations
 pub mod advanced;
 
-/// Optional parameters that can be provided when encrypting a new document.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct DocumentEncryptOpts {
-    id: Option<DocumentId>,
-    name: Option<DocumentName>,
-    // at least one user/group must be included either explicitly or via a policy
-    grants: EitherOrBoth<ExplicitGrant, PolicyGrant>,
-}
-
-/// Explicit users/groups that should have access to decrypt a document.
+/// Explicit list of users and groups that should have access to decrypt a document.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct ExplicitGrant {
     grant_to_author: bool,
@@ -36,8 +27,11 @@ pub struct ExplicitGrant {
 }
 
 impl ExplicitGrant {
-    /// `grant_to_author` - true if the calling user should have access to decrypt the document
-    /// `grants` - other UserOrGroups that should have access to the document
+    /// Construct a new ExplicitGrant.
+    ///
+    /// # Arguments
+    /// - `grant_to_author` - True if the calling user should have access to decrypt the document
+    /// - `grants` - List of users and groups that should have access to decrypt the document
     pub fn new(grant_to_author: bool, grants: &[UserOrGroup]) -> ExplicitGrant {
         ExplicitGrant {
             grant_to_author,
@@ -46,7 +40,31 @@ impl ExplicitGrant {
     }
 }
 
+/// Parameters that can be provided when encrypting a new document.
+///
+/// If no document ID is provided, one will be generated for it. If no document name is provided, the document's
+/// name will be left empty.
+///
+/// For default parameters, use `DocumentEncryptOpts::default()`.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct DocumentEncryptOpts {
+    id: Option<DocumentId>,
+    name: Option<DocumentName>,
+    // at least one user/group must be included either explicitly or via a policy
+    grants: EitherOrBoth<ExplicitGrant, PolicyGrant>,
+}
+
 impl DocumentEncryptOpts {
+    /// Constructs a new `DocumentEncryptOpts`.
+    ///
+    /// This requires either an `ExplicitGrant`, a `PolicyGrant`, or both. If only using one type
+    /// of grant, consider using [with_explicit_grants()](./struct.DocumentEncryptOpts.html#method.with_explicit_grants)
+    /// or [with_policy_grants()](./struct.DocumentEncryptOpts.html#method.with_policy_grants) instead.
+    ///
+    /// # Arguments
+    /// - `id` - Unique ID to use for the document. Note: this ID will **not** be encrypted.
+    /// - `name` - Non-unique name to use for the document. Note: this name will **not** be encrypted.
+    /// - `grants` - Grants that control who will be granted access to this encrypted document.
     pub fn new(
         id: Option<DocumentId>,
         name: Option<DocumentName>,
@@ -54,6 +72,14 @@ impl DocumentEncryptOpts {
     ) -> DocumentEncryptOpts {
         DocumentEncryptOpts { grants, name, id }
     }
+
+    /// Constructs a new `DocumentEncryptOpts` with access explicitly granted to certain users and groups.
+    ///
+    /// # Arguments
+    /// - `id` - Unique ID to use for the document. Note: this ID will **not** be encrypted.
+    /// - `name` - Non-unique name to use for the document. Note: this name will **not** be encrypted.
+    /// - `grant_to_author` - True if the calling user should have access to decrypt the document
+    /// - `grants` - List of users and groups that should have access to decrypt the document
     pub fn with_explicit_grants(
         id: Option<DocumentId>,
         name: Option<DocumentName>,
@@ -70,6 +96,12 @@ impl DocumentEncryptOpts {
         }
     }
 
+    /// Constructs a new `DocumentEncryptOpts` with access granted by a policy.
+    ///
+    /// # Arguments
+    /// - `id` - Unique ID to use for the document. Note: this ID will **not** be encrypted.
+    /// - `name` - Non-unique name to use for the document. Note: this name will **not** be encrypted.
+    /// - `grants` - Policy to determine what users and groups will have access to the document.
     pub fn with_policy_grants(
         id: Option<DocumentId>,
         name: Option<DocumentName>,
@@ -84,7 +116,9 @@ impl DocumentEncryptOpts {
 }
 
 impl Default for DocumentEncryptOpts {
-    /// default to only sharing with the creator of the document
+    /// Constructs a `DocumentEncryptOpts` with common values.
+    ///
+    /// The document will have a generated ID and no name. Access to the document will be granted only to its creator.
     fn default() -> Self {
         DocumentEncryptOpts::with_explicit_grants(None, None, true, vec![])
     }
@@ -92,105 +126,215 @@ impl Default for DocumentEncryptOpts {
 
 #[async_trait]
 pub trait DocumentOps {
-    /// List all of the documents that the current user is able to decrypt.
+    /// Encrypts the provided document bytes.
     ///
-    /// # Returns
-    /// `DocumentListResult` struct with vec of metadata about each document the user can decrypt.
-    async fn document_list(&self) -> Result<DocumentListResult>;
-
-    /// Get the metadata for a specific document given its ID.
-    ///
-    /// # Arguments
-    /// - `id` - Unique ID of the document to retrieve
-    ///
-    /// # Returns
-    /// `DocumentMetadataResult` with details about the requested document.
-    async fn document_get_metadata(&self, id: &DocumentId) -> Result<DocumentMetadataResult>;
-
-    /// Attempt to parse the document ID out of an encrypted document.
-    ///
-    /// # Arguments
-    /// - `encrypted_document` - Encrypted document bytes
-    ///
-    /// # Returns
-    /// `Result<DocumentId>` Fails if provided encrypted document has no header, otherwise returns extracted ID.
-    fn document_get_id_from_bytes(&self, encrypted_document: &[u8]) -> Result<DocumentId>;
-
-    /// Encrypt the provided document bytes.
+    /// This will create an entry for the document in the IronCore service. Returns a `DocumentEncryptResult`
+    /// which contains document metadata as well as the `encrypted_data`, which is the only thing that must be passed
+    /// to [document_decrypt()](trait.DocumentOps.html#tymethod.document_decrypt) in order to decrypt the document.
     ///
     /// # Arguments
     /// - `document_data` - Bytes of the document to encrypt
-    /// - `encrypt_opts` - Optional document encrypt parameters. Includes
-    ///       `id` - Unique ID to use for the document. Document ID will be stored unencrypted and must be unique per segment.
-    ///       `name` - Non-unique name to use in the document. Document name will **not** be encrypted.
-    ///       `grant_to_author` - Flag determining whether to encrypt to the calling user or not. If set to false at least one value must be present in the `grant` list.
-    ///       `grants` - List of users/groups to grant access to this document once encrypted
+    /// - `encrypt_opts` - Document encryption parameters. Default values are provided with `DocumentEncryptOpts::default()`.
+    ///
+    /// # Examples
+    /// ```
+    /// # async fn run() -> Result<(), ironoxide::IronOxideErr> {
+    /// # use ironoxide::prelude::*;
+    /// # let sdk: IronOxide = unimplemented!();
+    /// use ironoxide::document::DocumentEncryptOpts;
+    /// let data = "secret data".as_bytes();
+    /// let encrypted = sdk.document_encrypt(data, &DocumentEncryptOpts::default()).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     async fn document_encrypt(
         &self,
         document_data: &[u8],
         encrypt_opts: &DocumentEncryptOpts,
     ) -> Result<DocumentEncryptResult>;
 
-    /// Update the encrypted content of an existing document. Persists any existing access to other users and groups.
+    /// Decrypts an IronCore encrypted document.
+    ///
+    /// Returns details about the document as well as its decrypted bytes.
     ///
     /// # Arguments
-    /// - `id` - ID of document to update.
-    /// - `new_document_data` - Updated document content to encrypt.
+    /// - `encrypted_document` - Bytes of encrypted document. These should be the same bytes returned from
+    /// [document_encrypt()](trait.DocumentOps.html#tymethod.document_encrypt).
+    ///
+    /// # Errors
+    /// Fails if passed malformed data or if the calling user does not have sufficient access to the document.
+    ///
+    /// # Examples
+    /// ```
+    /// # async fn run() -> Result<(), ironoxide::IronOxideErr> {
+    /// # use ironoxide::prelude::*;
+    /// # let sdk: IronOxide = unimplemented!();
+    /// # let encrypted_data: Vec<u8> = vec![];
+    /// let decrypted_document = sdk.document_decrypt(&encrypted_data).await?;
+    /// let decrypted_data = decrypted_document.decrypted_data();
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn document_decrypt(&self, encrypted_document: &[u8]) -> Result<DocumentDecryptResult>;
+
+    /// Lists all of the IronCore encrypted documents that the calling user has been
+    /// granted access to.
+    ///
+    /// # Examples
+    /// ```
+    /// # async fn run() -> Result<(), ironoxide::IronOxideErr> {
+    /// # use ironoxide::prelude::*;
+    /// # use ironoxide::document::DocumentListMeta;
+    /// # let sdk: IronOxide = unimplemented!();
+    /// let document_data = sdk.document_list().await?;
+    /// let documents: Vec<DocumentListMeta> = document_data.result().to_vec();
+    /// # Ok(())
+    /// # }
+    async fn document_list(&self) -> Result<DocumentListResult>;
+
+    /// Returns the metadata for an IronCore encrypted document.
+    ///
+    /// # Arguments
+    /// - `id` - Unique ID of the document to retrieve
+    ///
+    /// # Examples
+    /// ```
+    /// # async fn run() -> Result<(), ironoxide::IronOxideErr> {
+    /// # use ironoxide::prelude::*;
+    /// # let sdk: IronOxide = unimplemented!();
+    /// # let document_id: DocumentId = unimplemented!();
+    /// let document_data = sdk.document_get_metadata(&document_id).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    async fn document_get_metadata(&self, id: &DocumentId) -> Result<DocumentMetadataResult>;
+
+    /// Returns the document ID from the bytes of an IronCore encrypted document.
+    ///
+    /// This is the same ID returned by `DocumentEncryptResult.id()`.
+    ///
+    /// # Arguments
+    /// - `encrypted_document` - Bytes of the encrypted document
+    ///
+    /// # Errors
+    /// Fails if the provided encrypted bytes have no header.
+    ///
+    /// # Examples
+    /// ```
+    /// # fn run() -> Result<(), ironoxide::IronOxideErr> {
+    /// # use ironoxide::prelude::*;
+    /// # let sdk: IronOxide = unimplemented!();
+    /// # let bytes: Vec<u8> = vec![];
+    /// let document_id = sdk.document_get_id_from_bytes(&bytes)?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn document_get_id_from_bytes(&self, encrypted_document: &[u8]) -> Result<DocumentId>;
+
+    /// Updates the contents of an existing IronCore encrypted document.
+    ///
+    /// The new contents will be encrypted, and which users and groups are granted access
+    /// will remain unchanged.
+    ///
+    /// # Arguments
+    /// - `id` - Unique ID of the document to update
+    /// - `new_document_data` - Updated bytes to encrypt
+    ///
+    /// # Examples
+    /// ```
+    /// # async fn run() -> Result<(), ironoxide::IronOxideErr> {
+    /// # use ironoxide::prelude::*;
+    /// # let sdk: IronOxide = unimplemented!();
+    /// # let document_id: DocumentId = unimplemented!();
+    /// let new_data = "more secret data".as_bytes();
+    /// let encrypted = sdk.document_update_bytes(&document_id, new_data).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     async fn document_update_bytes(
         &self,
         id: &DocumentId,
         new_document_data: &[u8],
     ) -> Result<DocumentEncryptResult>;
 
-    /// Decrypts the provided encrypted document and returns details about the document as well as its decrypted bytes.
+    /// Updates a document's name to a new value.
+    ///
+    /// Returns the updated metadata of the document.
     ///
     /// # Arguments
-    /// - `encrypted_document` - Bytes of encrypted document. Should be the same bytes returned from `document_encrypt`.
+    /// - `id` - Unique ID of the document to update
+    /// - `name` - New name for the document. Provide a `Some` to update to a new name or a `None` to clear the name field.
     ///
-    /// # Returns
-    /// `Result<DocumentDecryptResult>` Includes metadata about the provided document as well as the decrypted document bytes.
-    async fn document_decrypt(&self, encrypted_document: &[u8]) -> Result<DocumentDecryptResult>;
-
-    /// Update a document name to a new value or clear its value.
-    ///
-    /// # Arguments
-    /// - `id` - ID of the document to update
-    /// - `name` - New name for the document. Provide a Some to update to a new name and a None to clear the name field.
-    ///
-    /// # Returns
-    /// `Result<DocumentMetadataResult>` Metadata about the document that was updated.
+    /// # Examples
+    /// ```
+    /// # async fn run() -> Result<(), ironoxide::IronOxideErr> {
+    /// # use ironoxide::prelude::*;
+    /// # let sdk: IronOxide = unimplemented!();
+    /// # let document_id: DocumentId = unimplemented!();
+    /// use std::convert::TryFrom;
+    /// let new_name = DocumentName::try_from("updated")?;
+    /// let document_meta = sdk.document_update_name(&document_id, Some(&new_name)).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     async fn document_update_name(
         &self,
         id: &DocumentId,
         name: Option<&DocumentName>,
     ) -> Result<DocumentMetadataResult>;
 
-    /// Grant access to a document. Recipients of document access can be either users or groups.
+    /// Grants access to a document for a list of users and groups.
+    ///
+    /// Returns lists of successful and failed grants.
     ///
     /// # Arguments
-    /// `document_id` - id of the document whose access is is being modified
-    /// `grant_list` - list of grants. Elements represent either a user or a group.
+    /// `document_id` - Unique ID of the document whose access is being modified.
+    /// `grant_list` - List of users and groups to grant access to.
     ///
-    /// # Returns
-    /// Outer result indicates that the request failed either on the client or that the server rejected
-    /// the whole request. If the outer result is `Ok` then each individual grant to a user/group
-    /// either succeeded or failed.
+    /// # Examples
+    /// ```
+    /// # async fn run() -> Result<(), ironoxide::IronOxideErr> {
+    /// # use ironoxide::prelude::*;
+    /// # let sdk: IronOxide = unimplemented!();
+    /// # let document_id: DocumentId = unimplemented!();
+    /// # let users: Vec<UserId> = vec![];
+    /// use std::convert::TryFrom;
+    /// use ironoxide::document::UserOrGroup;
+    /// // from a list of UserIds, `users`
+    /// let users_or_groups: Vec<UserOrGroup> = users.iter().map(|user| user.into()).collect();
+    /// let access_result = sdk.document_grant_access(&document_id, &users_or_groups).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     async fn document_grant_access(
         &self,
         document_id: &DocumentId,
         grant_list: &Vec<UserOrGroup>,
     ) -> Result<DocumentAccessResult>;
 
-    /// Revoke access from a document. Revocation of document access can be either users or groups.
+    /// Revokes access to a document for a list of users and groups.
+    ///
+    /// Returns lists of successful and failed revocations.
     ///
     /// # Arguments
-    /// `document_id` - id of the document whose access is is being modified
-    /// `revoke_list` - List of revokes. Elements represent either a user or a group.
+    /// `document_id` - Unique ID of the document whose access is being modified.
+    /// `revoke_list` - List of users and groups to revoke access from.
     ///
-    /// # Returns
-    /// Outer result indicates that the request failed either on the client or that the server rejected
-    /// the whole request. If the outer result is `Ok` then each individual revoke from a user/group
-    /// either succeeded or failed.
+    /// # Examples
+    /// ```
+    /// # async fn run() -> Result<(), ironoxide::IronOxideErr> {
+    /// # use ironoxide::prelude::*;
+    /// # let sdk: IronOxide = unimplemented!();
+    /// # let document_id: DocumentId = unimplemented!();
+    /// # let users: Vec<UserId> = vec![];
+    /// use std::convert::TryFrom;
+    /// use ironoxide::document::UserOrGroup;
+    /// // from a list of UserIds, `users`
+    /// let users_or_groups: Vec<UserOrGroup> = users.iter().map(|user| user.into()).collect();
+    /// let access_result = sdk.document_revoke_access(&document_id, &users_or_groups).await?;
+    /// # Ok(())
+    /// # }
+    /// ```
     async fn document_revoke_access(
         &self,
         document_id: &DocumentId,
@@ -200,28 +344,6 @@ pub trait DocumentOps {
 
 #[async_trait]
 impl DocumentOps for crate::IronOxide {
-    async fn document_list(&self) -> Result<DocumentListResult> {
-        add_optional_timeout(
-            document_api::document_list(self.device.auth()),
-            self.config.sdk_operation_timeout,
-            SdkOperation::DocumentList,
-        )
-        .await?
-    }
-
-    async fn document_get_metadata(&self, id: &DocumentId) -> Result<DocumentMetadataResult> {
-        add_optional_timeout(
-            document_api::document_get_metadata(self.device.auth(), id),
-            self.config.sdk_operation_timeout,
-            SdkOperation::DocumentGetMetadata,
-        )
-        .await?
-    }
-
-    fn document_get_id_from_bytes(&self, encrypted_document: &[u8]) -> Result<DocumentId> {
-        document_api::get_id_from_bytes(encrypted_document)
-    }
-
     async fn document_encrypt(
         &self,
         document_data: &[u8],
@@ -268,6 +390,42 @@ impl DocumentOps for crate::IronOxide {
         .await?
     }
 
+    async fn document_decrypt(&self, encrypted_document: &[u8]) -> Result<DocumentDecryptResult> {
+        add_optional_timeout(
+            document_api::decrypt_document(
+                self.device.auth(),
+                &self.recrypt,
+                self.device.device_private_key(),
+                encrypted_document,
+            ),
+            self.config.sdk_operation_timeout,
+            SdkOperation::DocumentDecrypt,
+        )
+        .await?
+    }
+
+    async fn document_list(&self) -> Result<DocumentListResult> {
+        add_optional_timeout(
+            document_api::document_list(self.device.auth()),
+            self.config.sdk_operation_timeout,
+            SdkOperation::DocumentList,
+        )
+        .await?
+    }
+
+    async fn document_get_metadata(&self, id: &DocumentId) -> Result<DocumentMetadataResult> {
+        add_optional_timeout(
+            document_api::document_get_metadata(self.device.auth(), id),
+            self.config.sdk_operation_timeout,
+            SdkOperation::DocumentGetMetadata,
+        )
+        .await?
+    }
+
+    fn document_get_id_from_bytes(&self, encrypted_document: &[u8]) -> Result<DocumentId> {
+        document_api::get_id_from_bytes(encrypted_document)
+    }
+
     async fn document_update_bytes(
         &self,
         id: &DocumentId,
@@ -284,20 +442,6 @@ impl DocumentOps for crate::IronOxide {
             ),
             self.config.sdk_operation_timeout,
             SdkOperation::DocumentUpdateBytes,
-        )
-        .await?
-    }
-
-    async fn document_decrypt(&self, encrypted_document: &[u8]) -> Result<DocumentDecryptResult> {
-        add_optional_timeout(
-            document_api::decrypt_document(
-                self.device.auth(),
-                &self.recrypt,
-                self.device.device_private_key(),
-                encrypted_document,
-            ),
-            self.config.sdk_operation_timeout,
-            SdkOperation::DocumentDecrypt,
         )
         .await?
     }

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -26,10 +26,10 @@ use itertools::{Either, Itertools};
 use protobuf::{Message, RepeatedField};
 use rand::{self, CryptoRng, RngCore};
 use recrypt::{api::Plaintext, prelude::*};
-pub use requests::policy_get::PolicyResponse;
 use requests::{
     document_create,
     document_list::{DocumentListApiResponse, DocumentListApiResponseItem},
+    policy_get::PolicyResponse,
     DocumentMetaApiResponse,
 };
 use std::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //!
 //! ### Encrypting a Document
 //!
-//! For simple encryption to self, the [document_encrypt()](document/trait.DocumentOps.html#tymethod.document_encrypt) function can be
+//! For simple encryption to self, the [document_encrypt](document/trait.DocumentOps.html#tymethod.document_encrypt) function can be
 //! called with default values.
 //!
 //!```
@@ -46,7 +46,7 @@
 //! ### Decrypting a Document
 //!
 //! Decrypting a document is even simpler, as the only thing required by
-//! [document_decrypt()](document/trait.DocumentOps.html#tymethod.document_decrypt) is the bytes of the encrypted document.
+//! [document_decrypt](document/trait.DocumentOps.html#tymethod.document_decrypt) is the bytes of the encrypted document.
 //!
 //!```
 //! # async fn run() -> Result<(), ironoxide::IronOxideErr> {
@@ -158,7 +158,7 @@ pub mod config {
     ///
     /// Since policies are evaluated by the webservice, caching the result can greatly speed
     /// up encrypting a document with a [PolicyGrant](../policy/struct.PolicyGrant.html). There is no expiration of the cache, so
-    /// if you want to clear it at runtime, call [IronOxide::clear_policy_cache()](../struct.IronOxide.html#method.clear_policy_cache).
+    /// if you want to clear it at runtime, call [IronOxide::clear_policy_cache](../struct.IronOxide.html#method.clear_policy_cache).
     #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
     pub struct PolicyCachingConfig {
         /// maximum number of policy evaluations that will be cached by the SDK.
@@ -371,8 +371,8 @@ impl IronOxide {
     /// Rotate the private key of the calling user and all groups they are an administrator of where needs_rotation is true.
     /// Note that this function has the potential to take much longer than other functions, as rotation will be done
     /// individually on each user/group. If rotation is only needed for a specific group, it is strongly recommended
-    /// to call [user_rotate_private_key()](user\/trait.UserOps.html#tymethod.user_rotate_private_key) or
-    /// [group_rotate_private_key()](group\/trait.GroupOps.html#tymethod.group_rotate_private_key) instead.
+    /// to call [user_rotate_private_key](user\/trait.UserOps.html#tymethod.user_rotate_private_key) or
+    /// [group_rotate_private_key](group\/trait.GroupOps.html#tymethod.group_rotate_private_key) instead.
     /// # Arguments
     /// - `rotations` - PrivateKeyRotationCheckResult that holds all users and groups to be rotated
     /// - `password` - Password to unlock the current user's user master key

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,27 +5,59 @@
 //! SDK supports all possible operations that work in the IronCore platform including creating and managing users and groups, encrypting
 //! and decrypting document bytes, and granting and revoking access to documents to users and groups.
 //!
-//! ## [User Operations](user/trait.UserOps.html)
+//! # User Operations
 //!
-//! The IronOxide SDK user methods allow for multiple operations to manage your synced users/service accounts from your application
+//! The IronOxide SDK [user methods](user/trait.UserOps.html) allow for multiple operations to manage your synced users/service accounts from your application
 //! into the IronCore platform:
 //!
 //! + Lookup existing synced users in the IronCore system given their unique account IDs
 //! + Sync and generate cryptographic keys for authenticated users from your application into IronCore
 //! + List, create, and delete cryptographic device keys for synced users
-//! + List a users devices
+//! + List a user's devices
 //!
-//! ## [Document Operations](document/trait.DocumentOps.html)
+//! # Group Operations
+//!
+//! Groups are one of the many differentiating features of the IronCore platform. This SDK allows for easy management of your cryptographic
+//! groups. Groups can be created, updated, and deleted along with management of a group's administrators and members.
+//!
+//! # Document Operations
 //!
 //! All secret data that is encrypted using the IronCore platform are referred to as documents. Documents wrap the raw bytes of
 //! secret data to encrypt along with various metadata that helps convey access information to that data. Documents can be encrypted,
 //! decrypted, updated, granted to users and groups, and revoked from users and groups.
 //!
-//! ## [Group Operations](group/trait.GroupOps.html)
+//! ### Encrypting a Document
 //!
-//! Groups are one of the many differentiating features of the IronCore platform. This SDK allows for easy management of your cryptographic
-//! groups. Groups can be created, updated, and deleted along with management of a groups administrators and members.
+//! For simple encryption to self, the [document_encrypt()](document/trait.DocumentOps.html#tymethod.document_encrypt) function can be
+//! called with default values.
 //!
+//!```
+//! # async fn run() -> Result<(), ironoxide::IronOxideErr> {
+//! # use ironoxide::prelude::*;
+//! # let sdk: IronOxide = unimplemented!();
+//! use ironoxide::document::DocumentEncryptOpts;
+//! let data = "secret data".as_bytes();
+//! let encrypted = sdk.document_encrypt(data, &DocumentEncryptOpts::default()).await?;
+//! let encrypted_bytes = encrypted.encrypted_data();
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! ### Decrypting a Document
+//!
+//! Decrypting a document is even simpler, as the only thing required by
+//! [document_decrypt()](document/trait.DocumentOps.html#tymethod.document_decrypt) is the bytes of the encrypted document.
+//!
+//!```
+//! # async fn run() -> Result<(), ironoxide::IronOxideErr> {
+//! # use ironoxide::prelude::*;
+//! # let sdk: IronOxide = unimplemented!();
+//! # let encrypted_bytes: &[u8] = &[1;1];
+//! let document = sdk.document_decrypt(encrypted_bytes).await?;
+//! let decrypted_data = document.decrypted_data();
+//! # Ok(())
+//! # }
+//! ```
 
 // required by quick_error or IronOxideErr
 #![recursion_limit = "128"]
@@ -105,7 +137,7 @@ use recrypt::api::{Ed25519, RandomBytes, Recrypt, Sha256};
 use std::{convert::TryInto, fmt, sync::Mutex};
 use vec1::Vec1;
 
-/// Result of an Sdk operation
+/// A `Result` alias where the Err case is `IronOxideErr`
 pub type Result<T> = std::result::Result<T, IronOxideErr>;
 type PolicyCache = DashMap<PolicyGrant, Vec<WithKey<UserOrGroup>>>;
 

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -79,7 +79,7 @@ use crate::{internal::user_api::UserId, IronOxideErr, Result};
 use regex::Regex;
 use std::convert::TryFrom;
 
-/// Document access granted by a policy. For use with [DocumentOps.document_encrypt()](../document/trait.DocumentOps.html#tymethod.document_encrypt).
+/// Document access granted by a policy. For use with [DocumentOps.document_encrypt](../document/trait.DocumentOps.html#tymethod.document_encrypt).
 ///
 /// The triple (`category`, `sensitivity`, `data_subject`) maps to a single policy rule. Each policy
 /// rule may generate any number of users/groups.

--- a/src/policy.rs
+++ b/src/policy.rs
@@ -79,7 +79,7 @@ use crate::{internal::user_api::UserId, IronOxideErr, Result};
 use regex::Regex;
 use std::convert::TryFrom;
 
-/// Document access granted by a policy. For use with `DocumentOps.document_encrypt`.
+/// Document access granted by a policy. For use with [DocumentOps.document_encrypt()](../document/trait.DocumentOps.html#tymethod.document_encrypt).
 ///
 /// The triple (`category`, `sensitivity`, `data_subject`) maps to a single policy rule. Each policy
 /// rule may generate any number of users/groups.

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,3 @@
-#[doc(inline)]
 pub use crate::{
     document::DocumentOps,
     group::GroupOps,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,3 +1,4 @@
+#[doc(inline)]
 pub use crate::{
     document::DocumentOps,
     group::GroupOps,

--- a/tests/document_ops.rs
+++ b/tests/document_ops.rs
@@ -17,6 +17,21 @@ use itertools::EitherOrBoth;
 use std::convert::{TryFrom, TryInto};
 
 #[tokio::test]
+async fn doc_list() -> Result<(), IronOxideErr> {
+    let sdk = initialize_sdk().await?;
+    let (other_user, _) = init_sdk_get_user().await;
+    let doc = "secret".as_bytes();
+    // grant_to_author is false, but doc should still come back in document_list
+    let opts =
+        DocumentEncryptOpts::with_explicit_grants(None, None, false, vec![(&other_user).into()]);
+    sdk.document_encrypt(doc, &opts).await?;
+    let document_list = sdk.document_list().await?;
+    dbg!(&document_list);
+    assert_eq!(document_list.result().len(), 1);
+    Ok(())
+}
+
+#[tokio::test]
 async fn doc_roundtrip_empty_data() -> Result<(), IronOxideErr> {
     let sdk = initialize_sdk().await?;
     let doc = [0u8; 0];


### PR DESCRIPTION
Trying to make ironoxide more easily understood from the docs alone. This PR focuses on the `document` functions and things related to them. 

I added examples for every `DocumentOps` function, which are compiled (but not run, because of async issues) when running `cargo test`, helping prove that they don't become out-of-date.

I need feedback on how the landing page of the docs site should flow. My current thought is that each section (Users, Groups, Documents), as well as a higher level (like Initialization) will provide a bare-bones example of the most important functions to get you up and running. A reader could start at the top and see how to initialize, create a user, create a group, and encrypt/decrypt a document right from that page. There will also be links to important functions for each section.