### PR TITLE
Expand prelude

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,12 +1,15 @@
+#[doc(no_inline)]
 pub use crate::{
+    config::{IronOxideConfig, PolicyCachingConfig},
     document::DocumentOps,
     group::GroupOps,
     internal::{
         document_api::{DocumentId, DocumentName},
         group_api::{GroupId, GroupName},
         user_api::{DeviceId, DeviceName, UserId},
+        DeviceContext, DeviceSigningKeyPair, IronOxideErr, PrivateKey,
     },
     policy::PolicyGrant,
     user::UserOps,
-    DeviceContext, IronOxide, IronOxideErr,
+    IronOxide,
 };

--- a/src/search.rs
+++ b/src/search.rs
@@ -8,21 +8,24 @@
 //! The BlindIndexSearch gives the ability to generate queries as well as create the search entries to store.
 //!
 
-use crate::document::advanced::DocumentEncryptUnmanagedResult;
-use crate::document::advanced::*;
-use crate::document::DocumentEncryptOpts;
-use crate::internal::{take_lock, IronOxideErr};
-use crate::Result;
-use crate::{GroupId, IronOxide};
+use crate::{
+    document::{advanced::*, DocumentEncryptOpts},
+    internal::{take_lock, IronOxideErr},
+    GroupId, IronOxide, Result,
+};
 use async_trait::async_trait;
-use rand::rngs::adapter::ReseedingRng;
-use rand::rngs::OsRng;
-use rand::{self, RngCore, SeedableRng};
+use rand::{
+    self,
+    rngs::{adapter::ReseedingRng, OsRng},
+    RngCore, SeedableRng,
+};
 use rand_chacha::ChaChaCore;
-use std::collections::HashSet;
-use std::convert::{TryFrom, TryInto};
-use std::ops::DerefMut;
-use std::sync::Mutex;
+use std::{
+    collections::HashSet,
+    convert::{TryFrom, TryInto},
+    ops::DerefMut,
+    sync::Mutex,
+};
 
 use ironcore_search_helpers::{
     generate_hashes_for_string, generate_hashes_for_string_with_padding,

--- a/tests/search_ops.rs
+++ b/tests/search_ops.rs
@@ -3,9 +3,10 @@ mod common;
 #[cfg(feature = "beta")]
 mod search_tests {
     use crate::common::initialize_sdk;
-    use galvanic_assert::assert_that;
-    use galvanic_assert::matchers::collection::contains_subset;
-    use galvanic_assert::matchers::geq;
+    use galvanic_assert::{
+        assert_that,
+        matchers::{collection::contains_subset, geq},
+    };
     use ironoxide::{group::GroupOps, prelude::*, search::*};
 
     #[tokio::test]


### PR DESCRIPTION
Added to the prelude so it includes everything that's needed for initialization

If there are more things that would make sense to add, let me know

Cargo fmt also played with Colt's search imports, so sorry about that