### PR TITLE
Improve docs for document types

### DIFF
--- a/src/document/advanced.rs
+++ b/src/document/advanced.rs
@@ -1,3 +1,7 @@
+//! Advanced document types
+//!
+//! See [DocumentAdvancedOps](trait.DocumentAdvancedOps.html) for advanced document functions and key terms.
+
 pub use crate::internal::document_api::{
     DocumentDecryptUnmanagedResult, DocumentEncryptUnmanagedResult,
 };
@@ -9,37 +13,41 @@ use crate::{
 };
 use itertools::EitherOrBoth;
 
+/// IronOxide Advanced Document Operations
+///
+/// # Key Terms
+/// - ID     - The ID representing a document. It must be unique within the document's segment and will **not** be encrypted.
+/// - Name   - The human-readable name of a document. It does not need to be unique and will **not** be encrypted.
+/// - EDEKs  - Encrypted document encryption keys used by unmanaged document encryption and decryption.
 #[async_trait]
 pub trait DocumentAdvancedOps {
-    /// (Advanced) Encrypt the provided document bytes. Return the encrypted document encryption keys (EDEKs)
-    /// instead of creating a document entry in the IronCore webservice.
+    /// Encrypts the provided document bytes without being managed by the IronCore service.
+    ///
+    /// Returns the EDEKs instead of creating a document entry in the IronCore webservice.
     ///
     /// The webservice is still needed for looking up public keys and evaluating policies, but no
-    /// document is created and the edeks are not stored. An additional burden is put on the caller
-    /// in that the encrypted data AND the edeks need to be provided for decryption.
+    /// document is created and the EDEKs are not stored. An additional burden is put on the caller
+    /// in that both the encrypted data and the EDEKs must be provided for decryption.
     ///
     /// # Arguments
-    /// - `document_data` - Bytes of the document to encrypt
-    /// - `encrypt_opts` - Optional document encrypt parameters. Includes
-    ///       `id` - Unique ID to use for the document. Document ID will be stored unencrypted and must be unique per segment.
-    ///       `name` - (Ignored) - Any name provided will be ignored
-    ///       `grant_to_author` - Flag determining whether to encrypt to the calling user or not. If set to false at least one value must be present in the `grants` list.
-    ///       `grants` - List of users/groups to grant access to this document once encrypted
+    /// - `data` - Bytes of the document to encrypt
+    /// - `encrypt_opts` - Document encryption parameters. Default values are provided with `DocumentEncryptOpts::default()`.
     async fn document_encrypt_unmanaged(
         &self,
         data: &[u8],
         encrypt_opts: &DocumentEncryptOpts,
     ) -> Result<DocumentEncryptUnmanagedResult>;
 
-    /// (Advanced) Decrypt a document not managed by the ironcore service. Both the encrypted
-    /// data and the encrypted deks need to be provided.
+    /// Decrypts a document not managed by the IronCore service.
     ///
-    /// The webservice is still needed to transform a chosen encrypted dek so it can be decrypted
-    /// by the caller's private key.
+    /// Requires the encrypted data and EDEKs returned from
+    /// [document_encrypt_unmanaged](trait.DocumentAdvancedOps.html#tymethod.document_encrypt_unmanaged).
+    ///
+    /// The webservice is still needed to transform a chosen EDEK so it can be decrypted by the caller's private key.
     ///
     /// # Arguments
-    /// - `encrypted_data` - Encrypted document
-    /// - `encrypted_deks` - Associated encrypted DEKs for the `encrypted_data`
+    /// - `encrypted_data` - Bytes of the encrypted document
+    /// - `encrypted_deks` - EDEKs associated with the encrypted document
     async fn document_decrypt_unmanaged(
         &self,
         encrypted_data: &[u8],

--- a/src/document/advanced.rs
+++ b/src/document/advanced.rs
@@ -23,8 +23,6 @@ use itertools::EitherOrBoth;
 pub trait DocumentAdvancedOps {
     /// Encrypts the provided document bytes without being managed by the IronCore service.
     ///
-    /// Returns the EDEKs instead of creating a document entry in the IronCore webservice.
-    ///
     /// The webservice is still needed for looking up public keys and evaluating policies, but no
     /// document is created and the EDEKs are not stored. An additional burden is put on the caller
     /// in that both the encrypted data and the EDEKs must be provided for decryption.

--- a/src/document/advanced.rs
+++ b/src/document/advanced.rs
@@ -1,4 +1,4 @@
-//! Advanced document types
+//! Advanced document API
 //!
 //! See [DocumentAdvancedOps](trait.DocumentAdvancedOps.html) for advanced document functions and key terms.
 
@@ -16,9 +16,8 @@ use itertools::EitherOrBoth;
 /// IronOxide Advanced Document Operations
 ///
 /// # Key Terms
-/// - ID     - The ID representing a document. It must be unique within the document's segment and will **not** be encrypted.
-/// - Name   - The human-readable name of a document. It does not need to be unique and will **not** be encrypted.
-/// - EDEKs  - Encrypted document encryption keys used by unmanaged document encryption and decryption.
+/// - EDEKs - Encrypted document encryption keys produced by unmanaged document encryption and required for unmanaged
+///      document decryption.
 #[async_trait]
 pub trait DocumentAdvancedOps {
     /// Encrypts the provided document bytes without being managed by the IronCore service.
@@ -29,7 +28,8 @@ pub trait DocumentAdvancedOps {
     ///
     /// # Arguments
     /// - `data` - Bytes of the document to encrypt
-    /// - `encrypt_opts` - Document encryption parameters. Default values are provided with `DocumentEncryptOpts::default()`.
+    /// - `encrypt_opts` - Document encryption parameters. Default values are provided with
+    ///      [DocumentEncryptOpts::default()](../struct.DocumentEncryptOpts.html#method.default).
     async fn document_encrypt_unmanaged(
         &self,
         data: &[u8],

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -1,4 +1,4 @@
-//! Document types
+//! Document API
 //!
 //! See [DocumentOps](trait.DocumentOps.html) for document functions and key terms.
 
@@ -43,9 +43,10 @@ impl ExplicitGrant {
 /// Parameters that can be provided when encrypting a new document.
 ///
 /// Document IDs must be unique to the segment. If no ID is provided, one will be generated for it.
-/// If no name is provided, the document's name will be left empty.
+/// If no name is provided, the document's name will be left empty. Neither the document's ID nor name will
+/// be encrypted.
 ///
-/// Default values are provided with `DocumentEncryptOpts::default()`.
+/// Default values are provided with [DocumentEncryptOpts::default()](struct.DocumentEncryptOpts.html#method.default).
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentEncryptOpts {
     id: Option<DocumentId>,
@@ -143,7 +144,8 @@ pub trait DocumentOps {
     ///
     /// # Arguments
     /// - `document_data` - Bytes of the document to encrypt
-    /// - `encrypt_opts` - Document encryption parameters. Default values are provided with `DocumentEncryptOpts::default()`.
+    /// - `encrypt_opts` - Document encryption parameters. Default values are provided with
+    ///      [DocumentEncryptOpts::default()](struct.DocumentEncryptOpts.html#method.default).
     ///
     /// # Examples
     /// ```

--- a/src/document/mod.rs
+++ b/src/document/mod.rs
@@ -1,3 +1,7 @@
+//! Document types
+//!
+//! See [DocumentOps](trait.DocumentOps.html) for document functions and key terms.
+
 pub use crate::internal::document_api::{
     AssociationType, DocAccessEditErr, DocumentAccessResult, DocumentDecryptResult,
     DocumentEncryptResult, DocumentId, DocumentListMeta, DocumentListResult,
@@ -13,7 +17,6 @@ use crate::{
 };
 use itertools::{Either, EitherOrBoth, Itertools};
 
-/// Advanced document operations
 pub mod advanced;
 
 /// List of users and groups that should have access to decrypt a document.
@@ -24,10 +27,10 @@ pub struct ExplicitGrant {
 }
 
 impl ExplicitGrant {
-    /// Construct a new ExplicitGrant.
+    /// Constructs a new ExplicitGrant.
     ///
     /// # Arguments
-    /// - `grant_to_author` - True if the calling user should have access to decrypt the document
+    /// - `grant_to_author` - `true` if the calling user should have access to decrypt the document
     /// - `grants` - List of users and groups that should have access to decrypt the document
     pub fn new(grant_to_author: bool, grants: &[UserOrGroup]) -> ExplicitGrant {
         ExplicitGrant {
@@ -40,9 +43,9 @@ impl ExplicitGrant {
 /// Parameters that can be provided when encrypting a new document.
 ///
 /// Document IDs must be unique to the segment. If no ID is provided, one will be generated for it.
-/// If no document name is provided, the document's name will be left empty.
+/// If no name is provided, the document's name will be left empty.
 ///
-/// For default parameters, use `DocumentEncryptOpts::default()`.
+/// Default values are provided with `DocumentEncryptOpts::default()`.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentEncryptOpts {
     id: Option<DocumentId>,
@@ -50,7 +53,6 @@ pub struct DocumentEncryptOpts {
     // at least one user/group must be included either explicitly or via a policy
     grants: EitherOrBoth<ExplicitGrant, PolicyGrant>,
 }
-
 impl DocumentEncryptOpts {
     /// Constructs a new `DocumentEncryptOpts`.
     ///
@@ -59,8 +61,8 @@ impl DocumentEncryptOpts {
     /// or [with_policy_grants](./struct.DocumentEncryptOpts.html#method.with_policy_grants) instead.
     ///
     /// # Arguments
-    /// - `id` - Unique ID to use for the document. Note: this ID will **not** be encrypted.
-    /// - `name` - Non-unique name to use for the document. Note: this name will **not** be encrypted.
+    /// - `id` - ID to use for the document.
+    /// - `name` - Name to use for the document.
     /// - `grants` - Grants that control who will have access to read and decrypt this document.
     pub fn new(
         id: Option<DocumentId>,
@@ -73,8 +75,8 @@ impl DocumentEncryptOpts {
     /// Constructs a new `DocumentEncryptOpts` with access explicitly granted to certain users and groups.
     ///
     /// # Arguments
-    /// - `id` - Unique ID to use for the document. Note: this ID will **not** be encrypted.
-    /// - `name` - Non-unique name to use for the document. Note: this name will **not** be encrypted.
+    /// - `id` - ID to use for the document.
+    /// - `name` - Name to use for the document.
     /// - `grant_to_author` - True if the calling user should have access to decrypt the document
     /// - `grants` - List of users and groups that should have access to read and decrypt this document
     pub fn with_explicit_grants(
@@ -96,8 +98,8 @@ impl DocumentEncryptOpts {
     /// Constructs a new `DocumentEncryptOpts` with access granted by a policy.
     ///
     /// # Arguments
-    /// - `id` - Unique ID to use for the document. Note: this ID will **not** be encrypted.
-    /// - `name` - Non-unique name to use for the document. Note: this name will **not** be encrypted.
+    /// - `id` - ID to use for the document.
+    /// - `name` - Name to use for the document.
     /// - `policy` - Policy to determine which users and groups will have access to read and decrypt this document.
     ///              See the [policy](../policy/index.html) module for more information.
     pub fn with_policy_grants(
@@ -112,7 +114,6 @@ impl DocumentEncryptOpts {
         }
     }
 }
-
 impl Default for DocumentEncryptOpts {
     /// Constructs a `DocumentEncryptOpts` with common values.
     ///
@@ -123,6 +124,11 @@ impl Default for DocumentEncryptOpts {
     }
 }
 
+/// IronOxide Document Operations
+///
+/// # Key Terms
+/// - ID     - The ID representing a document. It must be unique within the document's segment and will **not** be encrypted.
+/// - Name   - The human-readable name of a document. It does not need to be unique and will **not** be encrypted.
 #[async_trait]
 pub trait DocumentOps {
     /// Encrypts the provided document bytes.
@@ -158,11 +164,12 @@ pub trait DocumentOps {
 
     /// Decrypts an IronCore encrypted document.
     ///
+    /// Requires the encrypted data returned from [document_encrypt](trait.DocumentOps.html#tymethod.document_encrypt).
+    ///
     /// Returns details about the document as well as its decrypted bytes.
     ///
     /// # Arguments
-    /// - `encrypted_document` - Bytes of encrypted document. These should be the same bytes returned from
-    /// [document_encrypt](trait.DocumentOps.html#tymethod.document_encrypt).
+    /// - `encrypted_document` - Bytes of the encrypted document
     ///
     /// # Errors
     /// Fails if passed malformed data or if the calling user does not have sufficient access to the document.
@@ -199,7 +206,7 @@ pub trait DocumentOps {
     /// This will not return the encrypted document bytes, as they are not stored by IronCore.
     ///
     /// # Arguments
-    /// - `id` - Unique ID of the document to retrieve
+    /// - `id` - ID of the document to retrieve
     ///
     /// # Examples
     /// ```
@@ -243,8 +250,8 @@ pub trait DocumentOps {
     /// will remain unchanged.
     ///
     /// # Arguments
-    /// - `id` - Unique ID of the document to update
-    /// - `new_document_data` - Updated bytes to encrypt
+    /// - `id` - ID of the document to update
+    /// - `new_document_data` - New document bytes to encrypt
     ///
     /// # Examples
     /// ```
@@ -268,7 +275,7 @@ pub trait DocumentOps {
     /// Returns the updated metadata of the document.
     ///
     /// # Arguments
-    /// - `id` - Unique ID of the document to update
+    /// - `id` - ID of the document to update
     /// - `name` - New name for the document. Provide a `Some` to update to a new name or a `None` to clear the name field.
     ///
     /// # Examples
@@ -294,7 +301,7 @@ pub trait DocumentOps {
     /// Returns lists of successful and failed grants.
     ///
     /// # Arguments
-    /// - `document_id` - Unique ID of the document whose access is being modified.
+    /// - `document_id` - ID of the document whose access is being modified.
     /// - `grant_list` - List of users and groups to grant access to.
     ///
     /// # Errors
@@ -327,7 +334,7 @@ pub trait DocumentOps {
     /// Returns lists of successful and failed revocations.
     ///
     /// # Arguments
-    /// - `document_id` - Unique ID of the document whose access is being modified.
+    /// - `document_id` - ID of the document whose access is being modified.
     /// - `revoke_list` - List of users and groups to revoke access from.
     ///
     /// # Errors

--- a/src/internal/document_api/mod.rs
+++ b/src/internal/document_api/mod.rs
@@ -45,10 +45,17 @@ const DOC_VERSION_HEADER_LENGTH: usize = 1;
 const HEADER_META_LENGTH_LENGTH: usize = 2;
 const CURRENT_DOCUMENT_ID_VERSION: u8 = 2;
 
-/// Document ID. Unique within the segment. Must match the regex `^[a-zA-Z0-9_.$#|@/:;=+'-]+$`
+/// ID of a document.
+///
+/// The ID can be validated from a `String` or `&str` using `DocumentId::try_from`.
+///
+/// # Requirements
+/// - Must be unique within the document's segment.
+/// - Must match the regex `^[a-zA-Z0-9_.$#|@/:;=+'-]+$`.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct DocumentId(pub(crate) String);
 impl DocumentId {
+    /// ID of the document.
     pub fn id(&self) -> &str {
         &self.0
     }
@@ -73,10 +80,17 @@ impl TryFrom<String> for DocumentId {
     }
 }
 
-/// (unencrypted) name of a document. Construct via `try_from(&str)`
+/// Name of a document.
+///
+/// The name should be human-readable and does not have to be unique.
+/// It can be validated from a `String` or `&str` using `DocumentName::try_from`.
+///
+/// # Requirements
+/// - Must be between 1 and 100 characters long.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct DocumentName(pub(crate) String);
 impl DocumentName {
+    /// Name of the document.
     pub fn name(&self) -> &String {
         &self.0
     }
@@ -99,7 +113,6 @@ struct DocumentHeader {
     #[serde(rename = "_sid_")]
     segment_id: usize,
 }
-
 impl DocumentHeader {
     fn new(document_id: DocumentId, segment_id: usize) -> DocumentHeader {
         DocumentHeader {
@@ -160,119 +173,138 @@ fn parse_document_parts(
     }
 }
 
-/// Represents the reason a document can be viewed by the requesting user.
+/// The reason a document can be viewed by the requesting user.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub enum AssociationType {
-    /// User created the document
+    /// User created the document.
     Owner,
-    /// User directly granted access to the document
+    /// User was directly granted access to the document.
     FromUser,
-    /// User granted access to the document via a group they are a member of
+    /// User was granted access to the document via a group they are a member of.
     FromGroup,
 }
 
-/// Represents a User struct which is returned from doc get to show the IDs of users the document is visible to
+/// User who is able to access a document.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct VisibleUser {
     id: UserId,
 }
 impl VisibleUser {
+    /// ID of the user
     pub fn id(&self) -> &UserId {
         &self.id
     }
 }
 
-/// Represents a Group struct which is returned from doc get to show the IDs and names of groups the document is visible to
+/// Group that is able to access a document.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct VisibleGroup {
     id: GroupId,
     name: Option<GroupName>,
 }
 impl VisibleGroup {
+    /// ID of the group
     pub fn id(&self) -> &GroupId {
         &self.id
     }
+    /// Name of the group
     pub fn name(&self) -> Option<&GroupName> {
         self.name.as_ref()
     }
 }
 
-/// Single document's (abbreviated) metadata. Returned as part of a `DocumentListResult`.
+/// Abbreviated document metadata.
 ///
-/// If you want full metadata for a document, see `DocumentMetadataResult`
+/// Result from [DocumentListResult.result()](struct.DocumentListResult.html#method.result).
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentListMeta(DocumentListApiResponseItem);
 impl DocumentListMeta {
+    /// ID of the document
     pub fn id(&self) -> &DocumentId {
         &self.0.id
     }
+    /// Name of the document
     pub fn name(&self) -> Option<&DocumentName> {
         self.0.name.as_ref()
     }
+    /// How the requesting user has access to the document
     pub fn association_type(&self) -> &AssociationType {
         &self.0.association.typ
     }
+    /// Date and time of when the document was created
     pub fn created(&self) -> &DateTime<Utc> {
         &self.0.created
     }
+    /// Date and time of when the document was last updated
     pub fn last_updated(&self) -> &DateTime<Utc> {
         &self.0.updated
     }
 }
 
-/// Metadata for each of the documents that the current user has access to decrypt.
+/// Metadata for each document the current user has access to.
+///
+/// Result from [document_list](trait.DocumentOps.html#tymethod.document_list).
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentListResult {
     result: Vec<DocumentListMeta>,
 }
 impl DocumentListResult {
+    /// Metadata for each document the current user has access to
     pub fn result(&self) -> &Vec<DocumentListMeta> {
         &self.result
     }
 }
 
 /// Full metadata for a document.
+///
+/// Result from [document_get_metadata](trait.DocumentOps.html#tymethod.document_get_metadata) and
+/// [document_update_name](trait.DocumentOps.html#tymethod.document_update_name).
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentMetadataResult(DocumentMetaApiResponse);
 impl DocumentMetadataResult {
+    /// ID of the document
     pub fn id(&self) -> &DocumentId {
         &self.0.id
     }
+    /// Name of the document
     pub fn name(&self) -> Option<&DocumentName> {
         self.0.name.as_ref()
     }
+    /// Date and time of when the document was created
     pub fn created(&self) -> &DateTime<Utc> {
         &self.0.created
     }
+    /// Date and time of when the document was last updated
     pub fn last_updated(&self) -> &DateTime<Utc> {
         &self.0.updated
     }
+    /// How the requesting user has access to the document
     pub fn association_type(&self) -> &AssociationType {
         &self.0.association.typ
     }
+    /// List of users who have access to the document
     pub fn visible_to_users(&self) -> &Vec<VisibleUser> {
         &self.0.visible_to.users
     }
+    /// List of groups that have access to the document
     pub fn visible_to_groups(&self) -> &Vec<VisibleGroup> {
         &self.0.visible_to.groups
     }
 
-    pub(crate) fn to_encrypted_symmetric_key(
-        &self,
-    ) -> Result<recrypt::api::EncryptedValue, IronOxideErr> {
+    // Not exposed outside of the crate
+    fn to_encrypted_symmetric_key(&self) -> Result<recrypt::api::EncryptedValue, IronOxideErr> {
         self.0.encrypted_symmetric_key.clone().try_into()
     }
 }
 
-/// Result for encrypt operations that do not store document access information with the webservice,
-/// but rather return the access information as `encrypted_deks`. Both the `encrypted_data` and
-/// `encrypted_deks` must be used to decrypt. See `document_edek_decrypt`
+/// Encrypted document bytes and metadata.
 ///
-/// - `id` - Unique (within the segment) id of the document
-/// - `encrypted_data` - Bytes of encrypted document content
-/// - `encrypted_deks` - List of encrypted document encryption keys (EDEK) of users/groups that have been granted access to `encrypted_data`
-/// - `access_errs` - Users and groups that could not be granted access
+/// Unmanaged encryption does not store document access information with the webservice,
+/// but rather returns the access information as `encrypted_deks`. Both the `encrypted_data` and
+/// `encrypted_deks` must be used to decrypt the document.
+///
+/// Result from [document_encrypt_unmanaged](trait.DocumentAdvancedOps.html#tymethod.document_encrypt_unmanaged).
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentEncryptUnmanagedResult {
     id: DocumentId,
@@ -281,14 +313,12 @@ pub struct DocumentEncryptUnmanagedResult {
     grants: Vec<UserOrGroup>,
     access_errs: Vec<DocAccessEditErr>,
 }
-
 impl DocumentEncryptUnmanagedResult {
     fn new(
         encryption_result: EncryptedDoc,
         access_errs: Vec<DocAccessEditErr>,
     ) -> Result<Self, IronOxideErr> {
         let edek_bytes = encryption_result.edek_bytes()?;
-
         Ok(DocumentEncryptUnmanagedResult {
             id: encryption_result.header.document_id.clone(),
             access_errs,
@@ -303,32 +333,32 @@ impl DocumentEncryptUnmanagedResult {
         })
     }
 
-    pub fn id(&self) -> &DocumentId {
-        &self.id
-    }
+    /// Bytes of encrypted document data
     pub fn encrypted_data(&self) -> &[u8] {
         &self.encrypted_data
     }
+    /// Bytes of encrypted document encryption keys (EDEK) of users/groups that have been granted access to `encrypted_data`
     pub fn encrypted_deks(&self) -> &[u8] {
         &self.encrypted_deks
     }
-    pub fn access_errs(&self) -> &[DocAccessEditErr] {
-        &self.access_errs
+    /// ID of the document
+    pub fn id(&self) -> &DocumentId {
+        &self.id
     }
+    /// Users and groups the document was successfully encrypted to
     pub fn grants(&self) -> &[UserOrGroup] {
         &self.grants
     }
+    /// Errors resulting from failure to encrypt
+    pub fn access_errs(&self) -> &[DocAccessEditErr] {
+        &self.access_errs
+    }
 }
 
-/// Result for encrypt operations.
+/// Encrypted document bytes and metadata.
 ///
-/// - `id` - Unique (within the segment) id of the document
-/// - `name` Non-unique document name. The document name is *not* encrypted.
-/// - `updated` - When the document was last updated
-/// - `created` - When the document was created
-/// - `encrypted_data` - Bytes of encrypted document content
-/// - `grants` - Users and groups that have access to decrypt the `encrypted_data`
-/// - `access_errs` - Users and groups that could not be granted access
+/// Result from [document_encrypt](trait.DocumentOps.html#tymethod.document_encrypt) and
+/// [document_update_bytes](trait.DocumentOps.html#tymethod.document_update_bytes).
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentEncryptResult {
     id: DocumentId,
@@ -340,29 +370,38 @@ pub struct DocumentEncryptResult {
     access_errs: Vec<DocAccessEditErr>,
 }
 impl DocumentEncryptResult {
-    pub fn id(&self) -> &DocumentId {
-        &self.id
-    }
-    pub fn name(&self) -> Option<&DocumentName> {
-        self.name.as_ref()
-    }
-    pub fn created(&self) -> &DateTime<Utc> {
-        &self.created
-    }
-    pub fn last_updated(&self) -> &DateTime<Utc> {
-        &self.updated
-    }
+    /// Bytes of encrypted document data
     pub fn encrypted_data(&self) -> &[u8] {
         &self.encrypted_data
     }
+    /// ID of the document
+    pub fn id(&self) -> &DocumentId {
+        &self.id
+    }
+    /// Name of the document
+    pub fn name(&self) -> Option<&DocumentName> {
+        self.name.as_ref()
+    }
+    /// Date and time of when the document was created
+    pub fn created(&self) -> &DateTime<Utc> {
+        &self.created
+    }
+    /// Date and time of when the document was last updated
+    pub fn last_updated(&self) -> &DateTime<Utc> {
+        &self.updated
+    }
+    /// Users and groups the document was successfully encrypted to
     pub fn grants(&self) -> &[UserOrGroup] {
         &self.grants
     }
+    /// Errors resulting from failure to encrypt
     pub fn access_errs(&self) -> &[DocAccessEditErr] {
         &self.access_errs
     }
 }
-/// Result of decrypting a document. Includes minimal metadata as well as the decrypted bytes.
+/// Decrypted document bytes and metadata.
+///
+/// Result from [document_decrypt](trait.DocumentOps.html#tymethod.document_decrypt).
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentDecryptResult {
     id: DocumentId,
@@ -372,32 +411,36 @@ pub struct DocumentDecryptResult {
     decrypted_data: Vec<u8>,
 }
 impl DocumentDecryptResult {
-    pub fn id(&self) -> &DocumentId {
-        &self.id
-    }
-    pub fn name(&self) -> Option<&DocumentName> {
-        self.name.as_ref()
-    }
-    pub fn created(&self) -> &DateTime<Utc> {
-        &self.created
-    }
-    pub fn last_updated(&self) -> &DateTime<Utc> {
-        &self.updated
-    }
+    /// Bytes of decrypted document data
     pub fn decrypted_data(&self) -> &[u8] {
         &self.decrypted_data
     }
+    /// ID of the document
+    pub fn id(&self) -> &DocumentId {
+        &self.id
+    }
+    /// Name of the document
+    pub fn name(&self) -> Option<&DocumentName> {
+        self.name.as_ref()
+    }
+    /// Date and time of when the document was created
+    pub fn created(&self) -> &DateTime<Utc> {
+        &self.created
+    }
+    /// Date and time of when the document was last updated
+    pub fn last_updated(&self) -> &DateTime<Utc> {
+        &self.updated
+    }
 }
 
-/// A failure to edit the access list of a document.
+/// Failure to edit a document's access list.
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocAccessEditErr {
-    /// User or group whose access was to be granted/revoked
+    /// User or group that was unable to have access granted/revoked.
     pub user_or_group: UserOrGroup,
-    /// Reason for failure
+    /// The error encountered when attempting to grant/revoke access.
     pub err: String,
 }
-
 impl DocAccessEditErr {
     pub(crate) fn new(user_or_group: UserOrGroup, err_msg: String) -> DocAccessEditErr {
         DocAccessEditErr {
@@ -407,14 +450,17 @@ impl DocAccessEditErr {
     }
 }
 
-/// Result of granting or revoking access to a document. Both grant and revoke support partial
-/// success.
+/// Successful and failed changes to a document's access list.
+///
+/// Both grant and revoke support partial success.
+///
+/// Result from [document_grant_access](trait.DocumentOps.html#tymethod.document_grant_access) and
+/// [document_revoke_access](trait.DocumentOps.html#tymethod.document_revoke_access).
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentAccessResult {
     succeeded: Vec<UserOrGroup>,
     failed: Vec<DocAccessEditErr>,
 }
-
 impl DocumentAccessResult {
     pub(crate) fn new(
         succeeded: Vec<UserOrGroup>,
@@ -423,12 +469,12 @@ impl DocumentAccessResult {
         DocumentAccessResult { succeeded, failed }
     }
 
-    /// Users whose access was successfully changed.
+    /// Users and groups whose access was successfully changed.
     pub fn succeeded(&self) -> &[UserOrGroup] {
         &self.succeeded
     }
 
-    /// Users whose access was not changed.
+    /// Users and groups whose access failed to be changed.
     pub fn failed(&self) -> &[DocAccessEditErr] {
         &self.failed
     }
@@ -436,39 +482,39 @@ impl DocumentAccessResult {
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct DecryptedData(Vec<u8>);
 
-/// Result of successful unmanaged decryption
+/// Decrypted document bytes and metadata.
+///
+/// Result from [document_decrypt_unmanaged](trait.DocumentAdvancedOps.html#tymethod.document_decrypt_unmanaged).
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub struct DocumentDecryptUnmanagedResult {
     id: DocumentId,
     access_via: UserOrGroup,
     decrypted_data: DecryptedData,
 }
-
 impl DocumentDecryptUnmanagedResult {
+    /// ID of the document
     pub fn id(&self) -> &DocumentId {
         &self.id
     }
-
-    /// user/group that granted access to the encrypted data. More specifically, the
-    /// user/group associated with the EDEK that was chosen and transformed by the webservice
+    /// User or group that granted access to the encrypted data
+    ///
+    /// More specifically, the user or group associated with the EDEK that was chosen and transformed by the webservice
     pub fn access_via(&self) -> &UserOrGroup {
         &self.access_via
     }
-
-    /// plaintext user data
+    /// Bytes of decrypt document data
     pub fn decrypted_data(&self) -> &[u8] {
         &self.decrypted_data.0
     }
 }
 
-/// Either a user or a group. Allows for containing both.
+/// A user or a group.
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum UserOrGroup {
     User { id: UserId },
     Group { id: GroupId },
 }
-
 impl std::fmt::Display for UserOrGroup {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
         match self {
@@ -477,16 +523,24 @@ impl std::fmt::Display for UserOrGroup {
         }
     }
 }
-
 impl From<&UserId> for UserOrGroup {
     fn from(u: &UserId) -> Self {
         UserOrGroup::User { id: u.clone() }
     }
 }
-
 impl From<&GroupId> for UserOrGroup {
     fn from(g: &GroupId) -> Self {
         UserOrGroup::Group { id: g.clone() }
+    }
+}
+impl From<UserId> for UserOrGroup {
+    fn from(u: UserId) -> Self {
+        UserOrGroup::User { id: u }
+    }
+}
+impl From<GroupId> for UserOrGroup {
+    fn from(g: GroupId) -> Self {
+        UserOrGroup::Group { id: g }
     }
 }
 
@@ -1794,7 +1848,7 @@ mod tests {
         )?
         .into_edoc(DocumentHeader::new(doc_id.clone(), seg_id));
 
-        // create an unmanged result, which does the proto serialization
+        // create an unmanaged result, which does the proto serialization
         let doc_encrypt_unmanaged_result =
             DocumentEncryptUnmanagedResult::new(encryption_result, vec![])?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,6 @@ include!(concat!(env!("OUT_DIR"), "/transform.rs"));
 #[cfg(feature = "beta")]
 pub mod search;
 
-/// SDK document operations
 pub mod document;
 
 /// SDK group operations

--- a/src/search.rs
+++ b/src/search.rs
@@ -6,6 +6,9 @@
 //! ## BlindIndexSearch
 //!
 //! The BlindIndexSearch gives the ability to generate queries as well as create the search entries to store.
+//!
+//! # Optional
+//! This requires the optional `beta` feature to be enabled.
 
 #[cfg(feature = "blocking")]
 use crate::blocking::BlockingIronOxide;


### PR DESCRIPTION
Improve the documentation for all of the `document` module types. 

Also added some convenience `From/TryFrom` implementations we were missing (`DocumentName`, `UserOrGroup`)