### PR TITLE
`proto` module is no longer `pub` in the crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   - Expose `transliterate_string` function
 - [[#155](https://github.com/IronCoreLabs/ironoxide/pull/155)]
   - Upgrade dependencies
+- [[#156](https://github.com/IronCoreLabs/ironoxide/pull/156)]
+  - `proto` module is no longer `pub` as it is only used internally
 
 ## 0.21.1
 

--- a/build.rs
+++ b/build.rs
@@ -32,7 +32,7 @@ fn main() {
         .unwrap()
         .read_to_string(&mut contents)
         .unwrap();
-    let new_contents = format!("pub mod proto {{pub mod {} {{ \n{}\n}}}}", name, contents);
+    let new_contents = format!("mod proto {{pub mod {} {{ \n{}\n}}}}", name, contents);
 
     File::create(&proto_path)
         .unwrap()


### PR DESCRIPTION
This module was never intended to be used outside of the crate.