### PR TITLE
Add public Jwt type

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
-        features: [--features tls-vendored-openssl --no-default-features]
+        features: [--features ""]
         toolchain: [stable]
         include:
           # different features combinations
@@ -29,7 +29,7 @@ jobs:
           - os: ubuntu-18.04
             features: --features tls-rustls --no-default-features
           - os: ubuntu-18.04
-            features: --features tls-default --no-default-features
+            features: --features tls-vendored-openssl --no-default-features
           # MSRV
           - os: ubuntu-18.04
             toolchain: 1.39.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # different operating systems
         os: [ubuntu-18.04, macos-10.15, windows-2019]
         features: [--features ""]
         toolchain: [stable]
@@ -25,7 +26,7 @@ jobs:
             features: --features blocking
           - os: ubuntu-18.04
             features: --features "blocking beta"
-          # different openssl implementations
+          # different tls implementations
           - os: ubuntu-18.04
             features: --features tls-rustls --no-default-features
           - os: ubuntu-18.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.23.0 (Unreleased)
+
+- []
+  - Add `Jwt` struct that validates JWT algorithm and payload form
+  - Change `user_create`, `user_verify`, and `generate_new_device` to use new `Jwt` struct
+
 ## 0.22.0
 
 - [[#142](https://github.com/IronCoreLabs/ironoxide/pull/142)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [[#164](https://github.com/IronCoreLabs/ironoxide/pull/164)]
   - Add `Jwt` struct that validates JWT algorithm and payload form
+  - Add `JwtClaims` struct to help form a valid `Jwt` payload
   - Change `user_create`, `user_verify`, and `generate_new_device` to use new `Jwt` struct
 
 ## 0.22.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.23.0 (Unreleased)
 
-- []
+- [[#164](https://github.com/IronCoreLabs/ironoxide/pull/164)]
   - Add `Jwt` struct that validates JWT algorithm and payload form
   - Change `user_create`, `user_verify`, and `generate_new_device` to use new `Jwt` struct
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,17 +16,17 @@ async-trait = "0.1.21"
 base64 = "~0.12.1"
 base64-serde = "~0.5.1"
 bytes = "~0.5"
-serde = {version = "~1.0", features = ["derive"]}
+serde = { version = "~1.0", features = ["derive"] }
 serde_json = "~1.0"
 # default features force a dependency on openssl-sys, which we want to avoid for embedded applications
-publicsuffix = { version="~1.5.4", default-features = false}
+publicsuffix = { version = "~1.5.4", default-features = false }
 rand = "~0.7"
 rand_chacha = "~0.2.2"
 regex = "~1.3"
-ring = { version= "~0.16", features = ["std"] }
+ring = { version = "~0.16", features = ["std"] }
 recrypt = "~0.11"
 url= "~2.1.0"
-reqwest = {version="~0.10.0", features = ["json"], default-features = false}
+reqwest = { version = "~0.10.0", features = ["json"], default-features = false }
 hex = "~0.4"
 itertools = "~0.9.0"
 futures = "~0.3.1"
@@ -35,20 +35,20 @@ lazy_static = "~1.4"
 chrono = { version = "~0.4", features = ["serde"] }
 percent-encoding="~2.1"
 log = "~0.4"
-protobuf = {version = "~2.14", features = ["with-bytes"]}
+protobuf = { version = "~2.14", features = ["with-bytes"] }
 vec1 = "~1.4.0"
 # ironoxide requires rt-threaded at runtime, but not at compile time
-tokio = {version = "~0.2.0", features=["time", "rt-threaded"]}
+tokio = { version = "~0.2.0", features = ["time", "rt-threaded"] }
 dashmap = "3.4.0"
-ironcore-search-helpers = { version="~0.1.0", optional=true}
+ironcore-search-helpers = { version = "~0.1.0", optional = true }
+jsonwebtoken = "~7.1"
 
 [dev-dependencies]
-frank_jwt = "~3.1.2"
 galvanic-assert = "~0.8"
 uuid = { version = "~0.8", features = ["v4"], default-features = false }
 double = "~0.2.4"
 criterion = "~0.3"
-tokio = {version = "~0.2.0", features = ["macros"]}
+tokio = { version = "~0.2.0", features = ["macros"] }
 
 [build-dependencies]
 protobuf-codegen-pure = "~2.14"

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -223,7 +223,7 @@ impl BlockingIronOxide {
     }
     /// See [ironoxide::user::UserOps::user_create](trait.UserOps.html#tymethod.user_create)
     pub fn user_create(
-        jwt: &str,
+        jwt: &Jwt,
         password: &str,
         user_create_opts: &UserCreateOpts,
         timeout: Option<std::time::Duration>,
@@ -245,7 +245,7 @@ impl BlockingIronOxide {
     }
     /// See [ironoxide::user::UserOps::generate_new_device](trait.UserOps.html#tymethod.generate_new_device)
     pub fn generate_new_device(
-        jwt: &str,
+        jwt: &Jwt,
         password: &str,
         device_create_options: &DeviceCreateOpts,
         timeout: Option<std::time::Duration>,
@@ -267,7 +267,7 @@ impl BlockingIronOxide {
     }
     /// See [ironoxide::user::UserOps::user_verify](trait.UserOps.html#tymethod.user_verify)
     pub fn user_verify(
-        jwt: &str,
+        jwt: &Jwt,
         timeout: Option<std::time::Duration>,
     ) -> Result<Option<UserResult>> {
         let rt = create_runtime();

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -660,40 +660,6 @@ impl<'de> Deserialize<'de> for DeviceSigningKeyPair {
     }
 }
 
-/// IronCore JWT.
-/// Should be either ES256 or RS256 and have a payload similar to:
-///
-/// let jwt_payload = json!({
-///     "pid" : project_id,
-///     "sid" : seg_id,
-///     "kid" : service_key_id,
-///     "iat" : issued_time_seconds,
-///     "exp" : expire_time_seconds,
-///     "sub" : unique_user_id
-/// });
-///
-#[derive(Clone, Debug, PartialEq, Serialize)]
-pub struct Jwt(String);
-impl TryFrom<&str> for Jwt {
-    type Error = IronOxideErr;
-    fn try_from(maybe_jwt: &str) -> Result<Self, Self::Error> {
-        //Valid JWTs are base64 encoded and have 3 segments separated by periods
-        if maybe_jwt.is_ascii() && maybe_jwt.matches('.').count() == 2 {
-            Ok(Jwt(maybe_jwt.to_string()))
-        } else {
-            Err(IronOxideErr::ValidationError(
-                "JWT".to_string(),
-                "must be valid ascii and be formatted correctly".to_string(),
-            ))
-        }
-    }
-}
-impl Jwt {
-    pub fn to_utf8(&self) -> Vec<u8> {
-        self.0.as_bytes().to_vec()
-    }
-}
-
 /// Newtype wrapper around a string which represents the users master private key escrow password
 #[derive(Debug, PartialEq)]
 pub struct Password(String);
@@ -987,24 +953,6 @@ pub(crate) mod tests {
     fn passphrase_validation() {
         let result = Password::try_from("");
         assert!(result.is_err())
-    }
-
-    #[test]
-    fn invalid_jwt_non_ascii() {
-        let jwt = Jwt::try_from("❤️.💣.💝");
-        assert!(jwt.is_err())
-    }
-
-    #[test]
-    fn invalid_jwt_format() {
-        let jwt = Jwt::try_from("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ");
-        assert!(jwt.is_err())
-    }
-
-    #[test]
-    fn valid_jwt_construction() {
-        let jwt = Jwt::try_from("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
-        assert!(jwt.is_ok())
     }
 
     #[test]

--- a/src/internal/rest.rs
+++ b/src/internal/rest.rs
@@ -122,7 +122,7 @@ impl<'a> Authorization<'a> {
     const VERSION_NUM: u8 = 2;
     pub fn to_auth_header(&self) -> HeaderMap {
         let auth_value = match self {
-            Authorization::JwtAuth(jwt) => format!("jwt {}", jwt.0)
+            Authorization::JwtAuth(jwt) => format!("jwt {}", jwt.jwt())
                 .parse()
                 .expect("IronCore JWTs should be ASCII"),
             Authorization::Version2 {

--- a/src/internal/rest.rs
+++ b/src/internal/rest.rs
@@ -1,8 +1,9 @@
 //! Helpers for talking to the ironcore service.
 
 use crate::internal::{
-    auth_v2::AuthV2Builder, user_api::UserId, DeviceSigningKeyPair, IronOxideErr, Jwt,
-    RequestErrorCode, OUR_REQUEST,
+    auth_v2::AuthV2Builder,
+    user_api::{Jwt, UserId},
+    DeviceSigningKeyPair, IronOxideErr, RequestErrorCode, OUR_REQUEST,
 };
 use bytes::Bytes;
 use chrono::{DateTime, Utc};

--- a/src/internal/user_api/requests.rs
+++ b/src/internal/user_api/requests.rs
@@ -10,8 +10,8 @@ use crate::{
             json::{Base64Standard, PublicKey},
             Authorization, IronCoreRequest,
         },
-        user_api::{DeviceName, UserId},
-        IronOxideErr, Jwt, RequestAuth, RequestErrorCode,
+        user_api::{DeviceName, Jwt, UserId},
+        IronOxideErr, RequestAuth, RequestErrorCode,
     },
 };
 use chrono::{DateTime, Utc};
@@ -307,8 +307,7 @@ pub mod user_key_list {
 pub mod device_add {
     use crate::internal::{
         rest::json::TransformKey,
-        user_api::{requests::PublicKey, DeviceAdd, DeviceId},
-        Jwt,
+        user_api::{requests::PublicKey, DeviceAdd, DeviceId, Jwt},
     };
 
     use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,10 +26,11 @@
 //! # async fn run() -> Result<(), ironoxide::IronOxideErr> {
 //! # use ironoxide::prelude::*;
 //! // Assuming an external function to get the jwt
-//! let jwt = get_jwt();
+//! let jwt_str = get_jwt();
+//! let jwt = Jwt::new(jwt_str)?;
 //! let password = "foobar";
 //! let opts = UserCreateOpts::new(false);
-//! let user_result = IronOxide::user_create(jwt, password, &opts, None).await?;
+//! let user_result = IronOxide::user_create(&jwt, password, &opts, None).await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -48,10 +49,11 @@
 //! # async fn run() -> Result<(), ironoxide::IronOxideErr> {
 //! # use ironoxide::prelude::*;
 //! // Assuming an external function to get the jwt
-//! let jwt = get_jwt();
+//! let jwt_str = get_jwt();
+//! let jwt = Jwt::new(jwt_str)?;
 //! let password = "foobar";
 //! let opts = DeviceCreateOpts::new(None);
-//! let device_result = IronOxide::generate_new_device(jwt, password, &opts, None).await?;
+//! let device_result = IronOxide::generate_new_device(&jwt, password, &opts, None).await?;
 //! // A `DeviceAddResult` can be converted into a `DeviceContext` used to initialize the SDK
 //! let device_context: DeviceContext = device_result.into();
 //! # Ok(())

--- a/src/user.rs
+++ b/src/user.rs
@@ -3,8 +3,9 @@
 //! See [UserOps](trait.UserOps.html) for user functions and key terms.
 
 pub use crate::internal::user_api::{
-    DeviceAddResult, DeviceId, DeviceName, EncryptedPrivateKey, Jwt, KeyPair, UserCreateResult,
-    UserDevice, UserDeviceListResult, UserId, UserResult, UserUpdatePrivateKeyResult,
+    DeviceAddResult, DeviceId, DeviceName, EncryptedPrivateKey, Jwt, JwtClaims, KeyPair,
+    UserCreateResult, UserDevice, UserDeviceListResult, UserId, UserResult,
+    UserUpdatePrivateKeyResult,
 };
 use crate::{
     common::{PublicKey, SdkOperation},

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,6 +1,6 @@
 use ironoxide::prelude::*;
 use lazy_static::*;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{convert::TryInto, default::Default};
 use uuid::Uuid;
 
@@ -65,31 +65,40 @@ lazy_static! {
     };
 }
 
-pub fn gen_jwt(account_id: Option<&str>) -> (String, String) {
+#[derive(Serialize, Deserialize)]
+struct Claims {
+    sub: String,
+    pid: usize,
+    sid: String,
+    kid: usize,
+    iat: u64,
+    exp: u64,
+}
+
+pub fn gen_jwt(account_id: Option<&str>) -> (Jwt, String) {
+    use jsonwebtoken::{Algorithm, EncodingKey, Header};
     use std::time::{SystemTime, UNIX_EPOCH};
     let start = SystemTime::now();
     let iat_seconds = start
         .duration_since(UNIX_EPOCH)
         .expect("Time before epoch? Something's wrong.")
         .as_secs();
-    let jwt_header = serde_json::json!({});
     let default_account_id = Uuid::new_v4().to_string();
     let sub = account_id.unwrap_or(&default_account_id);
-    let jwt_payload = serde_json::json!({
-        "pid" : CONFIG.project_id,
-        "sid" : CONFIG.segment_id,
-        "kid" : CONFIG.identity_assertion_key_id,
-        "iat" : iat_seconds,
-        "exp" : iat_seconds + 120,
-        "sub" : sub
-    });
-    let jwt = frank_jwt::encode(
-        jwt_header,
-        &KEYPATH.1.to_path_buf(),
-        &jwt_payload,
-        frank_jwt::Algorithm::ES256,
-    )
-    .unwrap_or_else(|_| panic!("Error with {}: You don't appear to have the proper service private key to sign the test JWT.", KEYPATH.0));
+    let my_claims = Claims {
+        sub: sub.to_string(),
+        pid: CONFIG.project_id,
+        sid: CONFIG.segment_id.clone(),
+        kid: CONFIG.identity_assertion_key_id,
+        iat: iat_seconds,
+        exp: iat_seconds + 120,
+    };
+    let header = Header::new(Algorithm::ES256);
+    let pem = std::fs::read_to_string(&KEYPATH.1).expect("Failed to open PEM file.");
+    let key = EncodingKey::from_ec_pem(pem.as_bytes()).expect("Invalid PEM file.");
+    let jwt_str = jsonwebtoken::encode(&header, &my_claims, &key).expect("Failed to encode JWT.");
+    let jwt = Jwt::new(&jwt_str).expect("Error creating IronCore JWT.");
+
     (jwt, sub.to_string())
 }
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,6 +1,6 @@
 use ironoxide::prelude::*;
 use lazy_static::*;
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use std::{convert::TryInto, default::Default};
 use uuid::Uuid;
 
@@ -65,16 +65,6 @@ lazy_static! {
     };
 }
 
-#[derive(Serialize, Deserialize)]
-struct Claims {
-    sub: String,
-    pid: usize,
-    sid: String,
-    kid: usize,
-    iat: u64,
-    exp: u64,
-}
-
 pub fn gen_jwt(account_id: Option<&str>) -> (Jwt, String) {
     use jsonwebtoken::{Algorithm, EncodingKey, Header};
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -85,13 +75,13 @@ pub fn gen_jwt(account_id: Option<&str>) -> (Jwt, String) {
         .as_secs();
     let default_account_id = Uuid::new_v4().to_string();
     let sub = account_id.unwrap_or(&default_account_id);
-    let my_claims = Claims {
+    let my_claims = JwtClaims {
         sub: sub.to_string(),
         pid: CONFIG.project_id,
         sid: CONFIG.segment_id.clone(),
         kid: CONFIG.identity_assertion_key_id,
         iat: iat_seconds,
-        exp: iat_seconds + 120,
+        exp: Some(iat_seconds + 120),
     };
     let header = Header::new(Algorithm::ES256);
     let pem = std::fs::read_to_string(&KEYPATH.1).expect("Failed to open PEM file.");

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -165,7 +165,7 @@ async fn user_create_with_needs_rotation() -> Result<(), IronOxideErr> {
 #[tokio::test]
 async fn generate_device_with_timeout() -> Result<(), IronOxideErr> {
     let result = IronOxide::generate_new_device(
-        common::gen_jwt(None).0.as_str(),
+        &common::gen_jwt(None).0,
         "pass",
         &Default::default(),
         Some(std::time::Duration::from_millis(1)),


### PR DESCRIPTION
Switched from `frank_jwt` to `jsonwebtoken`.

There already was an internal `Jwt` type, so re-purposed it and made it public. It validates that the jwt has the correct payload fields and an allowed algorithm. `user_create`, `user_verify`, and `generate_new_device` all use the new `Jwt` type instead of `&str`.

Also fixes:
- #162 
- #163 