### PR TITLE
Increase type_length_limit due to a change in Rust 1.46.0 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,16 @@
 # Changelog
 
-## (Unreleased)
+## Unreleased
+
+## 0.23.1
 
 - [[#170](https://github.com/IronCoreLabs/ironoxide/pull/170)]
   - Update `JwtClaims` struct to handle "http://ironcore/" namespace prefix on private claims
   - Add optional `uid` claim that is added by Auth0
   - Change type of `pid` and `kid` fields in claims from `usize` to `u32`
+- [[#177](https://github.com/IronCoreLabs/ironoxide/pull/177)]
+  - Add explicit `type_length_limit` because as of Rust 1.46.0, the default wasn't sufficient
+  - Update dependencies
 
 ## 0.23.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ vec1 = "~1.6.0"
 tokio = { version = "~0.2.0", features = ["time", "rt-threaded"] }
 dashmap = "3.4.0"
 ironcore-search-helpers = { version = "~0.1.2", optional = true }
-jsonwebtoken = "~7.0"
+jsonwebtoken = "~7.2"
 
 [dev-dependencies]
 galvanic-assert = "~0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ vec1 = "~1.6.0"
 tokio = { version = "~0.2.0", features = ["time", "rt-threaded"] }
 dashmap = "3.4.0"
 ironcore-search-helpers = { version = "~0.1.2", optional = true }
-jsonwebtoken = "7"
+jsonwebtoken = "~7.0"
 
 [dev-dependencies]
 galvanic-assert = "~0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,12 +36,12 @@ chrono = { version = "~0.4", features = ["serde"] }
 percent-encoding="~2.1"
 log = "~0.4"
 protobuf = { version = "~2.14", features = ["with-bytes"] }
-vec1 = "~1.4.0"
+vec1 = "~1.6.0"
 # ironoxide requires rt-threaded at runtime, but not at compile time
 tokio = { version = "~0.2.0", features = ["time", "rt-threaded"] }
 dashmap = "3.4.0"
 ironcore-search-helpers = { version = "~0.1.2", optional = true }
-jsonwebtoken = "~7.1.2"
+jsonwebtoken = "7"
 
 [dev-dependencies]
 galvanic-assert = "~0.8"

--- a/src/internal/user_api.rs
+++ b/src/internal/user_api.rs
@@ -312,7 +312,7 @@ impl Jwt {
         // This `dangerous_unsafe_decode` is safe because the server will do the actual
         // signature verification and validation. We just want to do a little initial validation
         // to catch issues earlier.
-        let token_data = jsonwebtoken::dangerous_unsafe_decode::<JwtClaims>(jwt)
+        let token_data = jsonwebtoken::dangerous_insecure_decode::<JwtClaims>(jwt)
             .map_err(|e| IronOxideErr::ValidationError("jwt".to_string(), e.to_string()))?;
         let alg = token_data.header.alg;
         if alg == Algorithm::ES256 || alg == Algorithm::RS256 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,7 +149,7 @@
 
 // required by quick_error or IronOxideErr
 #![recursion_limit = "128"]
-// required as of rust 1.46
+// required as of rust 1.46.0
 #![type_length_limit = "2000000"]
 
 // include generated proto code as a proto module

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,8 @@
 
 // required by quick_error or IronOxideErr
 #![recursion_limit = "128"]
+// required as of rust 1.46
+#![type_length_limit = "2000000"]
 
 // include generated proto code as a proto module
 include!(concat!(env!("OUT_DIR"), "/transform.rs"));


### PR DESCRIPTION
Rust 1.46.0 seems to be generating longer type names, or perhaps a change in one of our dependencies is causing this - I'm not sure. 
A limit of 1670000 was suggested by the compiler (and seemed to be enough), so I just rounded up to 2000000 to give us some headroom in case things internal names get longer again.

Also bumped a couple of dependencies.

The crate builds without the `type_length_limit` directive on Rust `1.45.2`, but does not on `1.46.0` or `1.47.0-nightly (2d8a3b918 2020-08-26)`