### PR TITLE
Upgrade to rust-protobuf 2.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # Changelog
 
 ## 0.24 (Unreleased)
-- TBD
+- [[#183](https://github.com/IronCoreLabs/ironoxide/pull/183)]
   - Update to rust-protobuf 2.17. Any downstream consumers that also use rust-protobuf will also need to update.
-
+- Lots of non-breaking dependency updates. (TODO List PRs here)
 
 
 ## 0.23.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## Unreleased
+## 0.24 (Unreleased)
+- TBD
+  - Update to rust-protobuf 2.17. Any downstream consumers that also use rust-protobuf will also need to update.
+
+
 
 ## 0.23.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ anyhow = "~1.0.31"
 
 [build-dependencies]
 protobuf-codegen-pure = "~2.17"
-itertools = "0.9.0"
+itertools = "~0.9.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ lazy_static = "~1.4"
 chrono = { version = "~0.4", features = ["serde"] }
 percent-encoding="~2.1"
 log = "~0.4"
-protobuf = { version = "~2.14", features = ["with-bytes"] }
+protobuf = { version = "~2.17", features = ["with-bytes"] }
 vec1 = "~1.6.0"
 # ironoxide requires rt-threaded at runtime, but not at compile time
 tokio = { version = "~0.2.0", features = ["time", "rt-threaded"] }
@@ -53,7 +53,8 @@ mut_static = "~5.0"
 anyhow = "~1.0.31"
 
 [build-dependencies]
-protobuf-codegen-pure = "~2.14"
+protobuf-codegen-pure = "~2.17"
+itertools = "0.9.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,4 @@
+use itertools::Itertools;
 use std::{
     env,
     fs::File,
@@ -32,7 +33,13 @@ fn main() {
         .unwrap()
         .read_to_string(&mut contents)
         .unwrap();
-    let new_contents = format!("mod proto {{pub mod {} {{ \n{}\n}}}}", name, contents);
+
+    let filtered: String = contents
+        .lines()
+        .filter(|line| line.trim() != "#![rustfmt::skip]")
+        .join("\n");
+
+    let new_contents = format!("mod proto {{pub mod {} {{ \n{}\n}}}}", name, filtered);
 
     File::create(&proto_path)
         .unwrap()

--- a/build.rs
+++ b/build.rs
@@ -34,7 +34,7 @@ fn main() {
         .read_to_string(&mut contents)
         .unwrap();
 
-    // Work around for https://github.com/rust-lang/rust/issues/5472
+    // Work around for https://github.com/rust-lang/rust/issues/54726
     // Introduced in rust-protobuf https://github.com/stepancheg/rust-protobuf/pull/495
     // More discussion: https://github.com/stepancheg/rust-protobuf/pull/523#issuecomment-701026992
     let filtered: String = contents

--- a/build.rs
+++ b/build.rs
@@ -34,6 +34,9 @@ fn main() {
         .read_to_string(&mut contents)
         .unwrap();
 
+    // Work around for https://github.com/rust-lang/rust/issues/5472
+    // Introduced in rust-protobuf https://github.com/stepancheg/rust-protobuf/pull/495
+    // More discussion: https://github.com/stepancheg/rust-protobuf/pull/523#issuecomment-701026992
     let filtered: String = contents
         .lines()
         .filter(|line| line.trim() != "#![rustfmt::skip]")


### PR DESCRIPTION
This is a breaking change for any downstream consumers that also use rust-protobuf. 
