### PR TITLE
Relax the semver requirement for protobuf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ lazy_static = "~1.4"
 chrono = { version = "~0.4", features = ["serde"] }
 percent-encoding="~2.1"
 log = "~0.4"
-protobuf = { version = "~2.17", features = ["with-bytes"] }
+protobuf = { version = "^2.0", features = ["with-bytes"] }
 vec1 = "~1.6.0"
 # ironoxide requires rt-threaded at runtime, but not at compile time
 tokio = { version = "~0.2.0", features = ["time", "rt-threaded"] }
@@ -53,7 +53,7 @@ mut_static = "~5.0"
 anyhow = "~1.0.31"
 
 [build-dependencies]
-protobuf-codegen-pure = "~2.17"
+protobuf-codegen-pure = "^2.0"
 itertools = "~0.9.0"
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
This will allow downstream consumers to choose their version of protobuf without causing build issues.

I realized this while looking at https://github.com/tikv/rust-prometheus/blob/master/Cargo.toml

I tested this by `git reset`ing logdriver to an old revision that used protobuf 2.14. It compiled file. It also compiled fine with a dependency of 2.17. 

There might still be problems in upgrading to newer version because we have custom `build.rs` logic for the proto generation, but at least cargo will be able to successfully select a version.

If we merge this, I think we can close https://github.com/IronCoreLabs/ironoxide/pull/188