### PR TITLE
Fix issue with serde 1.0.119

### DIFF
--- a/src/internal/rest.rs
+++ b/src/internal/rest.rs
@@ -13,15 +13,13 @@ use reqwest::{
     header::{HeaderMap, HeaderValue, CONTENT_TYPE},
     Client, Method, Request, RequestBuilder, StatusCode, Url,
 };
-use serde::{
-    de::DeserializeOwned,
-    export::{
-        fmt::{Display, Error},
-        Formatter,
-    },
-    Deserialize, Serialize,
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use std::{
+    borrow::BorrowMut,
+    fmt::{Display, Error, Formatter},
+    marker::PhantomData,
+    ops::Deref,
 };
-use std::{borrow::BorrowMut, marker::PhantomData, ops::Deref};
 
 lazy_static! {
     static ref DEFAULT_HEADERS: HeaderMap = {


### PR DESCRIPTION
Breaking change in patch bump :upside_down_face: 

For some reason, we were implementing `Display` using an export of `serde`, but apparently we weren't supposed to be able to import that (they renamed the module to `__private`). This change makes us implement `Display` in the standard way using `std::fmt::Display`, so the change is backwards compatible and we don't have to set a minimum version of `serde`.