### PR TITLE
Change all dependencies to default upgrade requirements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ reqwest = { version = "0.11", features = [ "json" ], default-features = false }
 ring = { version = "0.16", features = [ "std" ] }
 serde = { version = "1.0.123", features = [ "derive" ] }
 serde_json = "1"
-tokio = { version = "1.2", features = [ "time" ] }
+tokio = { version = "1", features = [ "time" ] }
 url = "2.2"
 vec1 = "1.6"
 
@@ -48,7 +48,7 @@ criterion = "0.3"
 double = "0.2.4"
 galvanic-assert = "0.8"
 mut_static = "5"
-tokio = { version = "1.2", features = [ "macros", "rt-multi-thread" ] }
+tokio = { version = "1", features = [ "macros", "rt-multi-thread" ] }
 uuid = { version = "0.8", features = [ "v4" ], default-features = false }
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,47 +13,47 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1.21"
-base64 = "~0.13.0"
-base64-serde = "~0.6.1"
-bytes = "~1.0"
-chrono = { version = "~0.4", features = [ "serde" ] }
+base64 = "0.13.0"
+base64-serde = "0.6.1"
+bytes = "1.0"
+chrono = { version = "0.4", features = [ "serde" ] }
 dashmap = "4.0.1"
-futures = "~0.3.1"
-hex = "~0.4"
-ironcore-search-helpers = { version = "~0.1.2", optional = true }
-itertools = "~0.10.0"
-jsonwebtoken = "~7.2"
-lazy_static = "~1.4"
-log = "~0.4"
-percent-encoding = "~2.1"
-protobuf = { version = "^2.20", features = [ "with-bytes" ] }
+futures = "0.3.1"
+hex = "0.4"
+ironcore-search-helpers = { version = "0.1.2", optional = true }
+itertools = "0.10.0"
+jsonwebtoken = "7.2"
+lazy_static = "1.4"
+log = "0.4"
+percent-encoding = "2.1"
+protobuf = { version = "2.20", features = [ "with-bytes" ] }
 # default features force a dependency on openssl-sys, which we want to avoid for embedded applications
-publicsuffix = { version = "~1.5.4", default-features = false }
-quick-error = "~2.0"
-rand = "~0.7"
-rand_chacha = "~0.2.2"
-recrypt = "~0.12"
-regex = "~1.4"
-reqwest = { version = "~0.11.0", features = [ "json" ], default-features = false }
-ring = { version = "~0.16", features = [ "std" ] }
-serde = { version = "~1.0", features = [ "derive" ] }
-serde_json = "~1.0"
-tokio = { version = "~1.2", features = [ "time" ] }
-url = "~2.2.0"
-vec1 = "~1.6.0"
+publicsuffix = { version = "1.5.4", default-features = false }
+quick-error = "2.0"
+rand = "0.7"
+rand_chacha = "0.2.2"
+recrypt = "0.12"
+regex = "1.4"
+reqwest = { version = "0.11.0", features = [ "json" ], default-features = false }
+ring = { version = "0.16", features = [ "std" ] }
+serde = { version = "1.0", features = [ "derive" ] }
+serde_json = "1.0"
+tokio = { version = "1.0", features = [ "time" ] }
+url = "2.2.0"
+vec1 = "1.6.0"
 
 [dev-dependencies]
-anyhow = "~1.0.31"
-criterion = "~0.3"
-double = "~0.2.4"
-galvanic-assert = "~0.8"
-mut_static = "~5.0"
-tokio = { version = "~1.2", features = [ "macros", "rt-multi-thread" ] }
-uuid = { version = "~0.8", features = [ "v4" ], default-features = false }
+anyhow = "1.0.31"
+criterion = "0.3"
+double = "0.2.4"
+galvanic-assert = "0.8"
+mut_static = "5.0"
+tokio = { version = "1.2", features = [ "macros", "rt-multi-thread" ] }
+uuid = { version = "0.8", features = [ "v4" ], default-features = false }
 
 [build-dependencies]
-itertools = "~0.10.0"
-protobuf-codegen-pure = "^2.20"
+itertools = "0.10.0"
+protobuf-codegen-pure = "2.20"
 
 [features]
 beta = [ "ironcore-search-helpers" ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,46 +13,46 @@ edition = "2018"
 
 [dependencies]
 async-trait = "0.1.21"
-base64 = "0.13.0"
+base64 = "0.13"
 base64-serde = "0.6.1"
-bytes = "1.0"
+bytes = "1"
 chrono = { version = "0.4", features = [ "serde" ] }
-dashmap = "4.0.1"
+dashmap = "4"
 futures = "0.3.1"
 hex = "0.4"
 ironcore-search-helpers = { version = "0.1.2", optional = true }
-itertools = "0.10.0"
+itertools = "0.10"
 jsonwebtoken = "7.2"
 lazy_static = "1.4"
 log = "0.4"
 percent-encoding = "2.1"
 protobuf = { version = "2.20", features = [ "with-bytes" ] }
 # default features force a dependency on openssl-sys, which we want to avoid for embedded applications
-publicsuffix = { version = "1.5.4", default-features = false }
-quick-error = "2.0"
+publicsuffix = { version = "1.5", default-features = false }
+quick-error = "2"
 rand = "0.7"
 rand_chacha = "0.2.2"
 recrypt = "0.12"
 regex = "1.4"
-reqwest = { version = "0.11.0", features = [ "json" ], default-features = false }
+reqwest = { version = "0.11", features = [ "json" ], default-features = false }
 ring = { version = "0.16", features = [ "std" ] }
-serde = { version = "1.0", features = [ "derive" ] }
-serde_json = "1.0"
+serde = { version = "1", features = [ "derive" ] }
+serde_json = "1"
 tokio = { version = "1.2", features = [ "time" ] }
-url = "2.2.0"
-vec1 = "1.6.0"
+url = "2.2"
+vec1 = "1.6"
 
 [dev-dependencies]
-anyhow = "1.0.31"
+anyhow = "1"
 criterion = "0.3"
 double = "0.2.4"
 galvanic-assert = "0.8"
-mut_static = "5.0"
+mut_static = "5"
 tokio = { version = "1.2", features = [ "macros", "rt-multi-thread" ] }
 uuid = { version = "0.8", features = [ "v4" ], default-features = false }
 
 [build-dependencies]
-itertools = "0.10.0"
+itertools = "0.10"
 protobuf-codegen-pure = "2.20"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ reqwest = { version = "0.11.0", features = [ "json" ], default-features = false 
 ring = { version = "0.16", features = [ "std" ] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_json = "1.0"
-tokio = { version = "1.0", features = [ "time" ] }
+tokio = { version = "1.2", features = [ "time" ] }
 url = "2.2.0"
 vec1 = "1.6.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ recrypt = "0.12"
 regex = "1.4"
 reqwest = { version = "0.11", features = [ "json" ], default-features = false }
 ring = { version = "0.16", features = [ "std" ] }
-serde = { version = "1", features = [ "derive" ] }
+serde = { version = "1.0.123", features = [ "derive" ] }
 serde_json = "1"
 tokio = { version = "1.2", features = [ "time" ] }
 url = "2.2"


### PR DESCRIPTION
Changes from `~` requirements to no symbol (which is equivalent to `^` requirements). From the docs:
> Caret requirements allow SemVer compatible updates to a specified version. An update is allowed if the new version number  > does not modify the left-most non-zero digit in the major, minor, patch grouping. In this case, if we ran cargo update -p time,  cargo should update us to version 0.1.13 if it is the latest 0.1.z release, but would not update us to 0.2.0. If instead we had specified the version string as ^1.0, cargo should update to 1.1 if it is the latest 1.y release, but not 2.0. The version 0.0.x is not considered compatible with any other version.
This compatibility convention is different from SemVer in the way it treats versions before 1.0.0. While SemVer says there is no compatibility before 1.0.0, Cargo considers 0.x.y to be compatible with 0.x.z, where y ≥ z and x > 0.