### PR TITLE
Remove dependency on publicsuffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.25.2 (Unreleased)
 
 - [[#225](https://github.com/IronCoreLabs/ironoxide/pull/225)] Fix bug causing requests with empty policies to fail.
+- [[#232](https://github.com/IronCoreLabs/ironoxide/pull/232)] Remove dependency on publicsuffix.
 
 ## 0.25.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,6 @@ lazy_static = "1.4"
 log = "0.4"
 percent-encoding = "2.1"
 protobuf = { version = "2.20", features = [ "with-bytes" ] }
-# default features force a dependency on openssl-sys, which we want to avoid for embedded applications
-publicsuffix = { version = "1.5", default-features = false }
 quick-error = "2"
 rand = "0.7"
 rand_chacha = "0.2.2"


### PR DESCRIPTION
As discovered in #231, we were only using publicsuffix for the `IntoUrl` trait. Instead, we can just call `url::Url::parse` directly ourselves.