### PR TITLE
Don't clone plaintext on aes encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## 0.27.0 (Unreleased)
-- [[#249](https://github.com/IronCoreLabs/ironoxide/pull/249)] Remove `chrono` types in public API and replace with equivalent `time` types.
+## 0.27.0
+- [[#246](https://github.com/IronCoreLabs/ironoxide/pull/246)] Don't clone plaintext on AES encryption
+  - Public APIs for `document_encrypt`, `document_encrypt_unmanaged`, and `document_update_bytes` now take owned bytes instead of byte slices to improve performance for common use cases.
+  - AES encryption has improved memory usage in most cases.
+- [[#249](https://github.com/IronCoreLabs/ironoxide/pull/249)] Remove `chrono` types in public API and replace with equivalent `time` types
 - [[#248](https://github.com/IronCoreLabs/ironoxide/pull/248)]
   - Bump MSRV to 1.56.0
   - Update to recrypt 0.13

--- a/benches/ironoxide_bench.rs
+++ b/benches/ironoxide_bench.rs
@@ -52,14 +52,14 @@ fn criterion_benchmark(c: &mut Criterion) {
 
         // encrypted data to user to decrypt
         let enc_result = io
-            .document_encrypt(&data, &Default::default())
+            .document_encrypt(data.into(), &Default::default())
             .await
             .expect("encryption failed");
         let enc_data = enc_result.encrypted_data().to_vec();
 
         // (unmanaged) encrypted data/deks to user to decrypt
         let enc_result_unmanaged = io
-            .document_encrypt_unmanaged(&data, &Default::default())
+            .document_encrypt_unmanaged(data.into(), &Default::default())
             .await
             .expect("encryption failed");
         let (enc_data_unmanaged, enc_deks_unmanaged) = (
@@ -84,7 +84,7 @@ fn criterion_benchmark(c: &mut Criterion) {
         // data encrypted to a group to decrypt
         let group_enc_result = io
             .document_encrypt_unmanaged(
-                &data,
+                data.into(),
                 &DocumentEncryptOpts::with_explicit_grants(None, None, false, vec![group1.into()]),
             )
             .await
@@ -125,11 +125,13 @@ fn criterion_benchmark(c: &mut Criterion) {
     });
 
     c.bench_function("document encrypt [self]", |b| {
-        b.iter(|| rt.block_on(io.document_encrypt(black_box(&data), &Default::default())))
+        b.iter(|| rt.block_on(io.document_encrypt(black_box(data.into()), &Default::default())))
     });
 
     c.bench_function("document encrypt (unmanaged) [self]", |b| {
-        b.iter(|| rt.block_on(io.document_encrypt_unmanaged(black_box(&data), &Default::default())))
+        b.iter(|| {
+            rt.block_on(io.document_encrypt_unmanaged(black_box(data.into()), &Default::default()))
+        })
     });
 
     c.bench_function("document encrypt [self, group]", |b| {
@@ -140,7 +142,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 true,
                 vec![group1.clone().into()],
             );
-            rt.block_on(io.document_encrypt(black_box(&data), &opts))
+            rt.block_on(io.document_encrypt(black_box(data.into()), &opts))
         })
     });
 
@@ -152,7 +154,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 true,
                 vec![group1.clone().into(), group2.clone().into()],
             );
-            rt.block_on(io.document_encrypt(black_box(&data), &opts))
+            rt.block_on(io.document_encrypt(black_box(data.into()), &opts))
         })
     });
 

--- a/examples/decrypting.rs
+++ b/examples/decrypting.rs
@@ -106,7 +106,7 @@ async fn generate_encrypted_documents(
     println!("Encrypting {} documents...", number_of_documents);
     let opts = DocumentEncryptOpts::default();
     let encrypted_documents = futures::future::try_join_all(
-        (0..number_of_documents).map(|_| sdk.document_encrypt(b"foobar", &opts)),
+        (0..number_of_documents).map(|_| sdk.document_encrypt(b"foobar".to_vec(), &opts)),
     )
     .await;
     println!("Done\n");

--- a/examples/enc-search-sample.rs
+++ b/examples/enc-search-sample.rs
@@ -110,25 +110,25 @@ async fn main() -> Result<()> {
         name: "Gumby".to_string(),
         email: "gumby@gumby.io".to_string(),
     };
-    save_customer(&cust1, &group_id, &sdk, &blind_index).await?;
+    save_customer(cust1, &group_id, &sdk, &blind_index).await?;
     let cust2 = Customer {
         id: 2,
         name: "Æ neid 北亰".to_string(),
         email: "".to_string(),
     };
-    save_customer(&cust2, &group_id, &sdk, &blind_index).await?;
+    save_customer(cust2, &group_id, &sdk, &blind_index).await?;
     let cust3 = Customer {
         id: 3,
         name: "aeneid bei jing".to_string(),
         email: "".to_string(),
     };
-    save_customer(&cust3, &group_id, &sdk, &blind_index).await?;
+    save_customer(cust3, &group_id, &sdk, &blind_index).await?;
     let cust4 = Customer {
         id: 4,
         name: "J. Fred Muggs".to_string(),
         email: "j.fred.muggs@nowhere.com".to_string(),
     };
-    save_customer(&cust4, &group_id, &sdk, &blind_index).await?;
+    save_customer(cust4, &group_id, &sdk, &blind_index).await?;
 
     // Allow the user to enter additional customers
     add_customers(&4, &group_id, &sdk, &blind_index).await?;
@@ -157,7 +157,7 @@ async fn main() -> Result<()> {
         name: "Pokey".to_string(),
         email: "pokey@gumby.io".to_string(),
     };
-    save_customer_with_2_indices(&cust24, &group_id, &sdk, &blind_index, &blind_index2).await?;
+    save_customer_with_2_indices(cust24, &group_id, &sdk, &blind_index, &blind_index2).await?;
 
     Ok(())
 }
@@ -192,7 +192,7 @@ async fn add_customers(
                 name: name,
                 email: email,
             };
-            save_customer(&cust, &group_id, &sdk, &blind_index).await?;
+            save_customer(cust, &group_id, &sdk, &blind_index).await?;
         }
         next_id += 1;
     }
@@ -204,7 +204,7 @@ async fn add_customers(
 // field, generate the index tokens for the name, encrypt the name and email, and save the
 // customer record with the index tokens to the server.
 async fn save_customer(
-    cust: &Customer,
+    cust: Customer,
     group_id: &ironoxide::group::GroupId,
     sdk: &ironoxide::IronOxide,
     blind_index: &ironoxide::search::BlindIndexSearch,
@@ -225,10 +225,10 @@ async fn save_customer(
         vec![group_id.into()], // users and groups to which to grant access
     );
     let enc_name = sdk
-        .document_encrypt_unmanaged(cust.name.as_bytes(), &encrypt_opts)
+        .document_encrypt_unmanaged(cust.name.into_bytes(), &encrypt_opts)
         .await?;
     let enc_email = sdk
-        .document_encrypt_unmanaged(cust.email.as_bytes(), &encrypt_opts)
+        .document_encrypt_unmanaged(cust.email.into_bytes(), &encrypt_opts)
         .await?;
 
     let enc_cust = EncryptedCustomer {
@@ -248,7 +248,7 @@ async fn save_customer(
 // and email fields, generate the index tokens for the name and for the email, encrypt the
 // name and email, and save the customer record with both sets of index tokens to the server.
 async fn save_customer_with_2_indices(
-    cust: &Customer,
+    cust: Customer,
     group_id: &ironoxide::group::GroupId,
     sdk: &ironoxide::IronOxide,
     name_blind_index: &ironoxide::search::BlindIndexSearch,
@@ -274,10 +274,10 @@ async fn save_customer_with_2_indices(
         vec![group_id.into()], // users and groups to which to grant access
     );
     let enc_name = sdk
-        .document_encrypt_unmanaged(cust.name.as_bytes(), &encrypt_opts)
+        .document_encrypt_unmanaged(cust.name.into_bytes(), &encrypt_opts)
         .await?;
     let enc_email = sdk
-        .document_encrypt_unmanaged(cust.email.as_bytes(), &encrypt_opts)
+        .document_encrypt_unmanaged(cust.email.into_bytes(), &encrypt_opts)
         .await?;
 
     let enc_cust = EncryptedCustomer {

--- a/examples/encrypting.rs
+++ b/examples/encrypting.rs
@@ -18,10 +18,10 @@ async fn main() -> Result<()> {
 async fn encrypt_to_group(sdk: &IronOxide) -> Result<DocumentId> {
     // start-snippet{encryptToGroup}
     let group_id = create_group(sdk).await?;
-    let message = "This is my secret which a whole group should see.";
+    let message = "This is my secret which a whole group should see.".to_string();
     let encrypted_result = sdk
         .document_encrypt(
-            message.as_bytes(),
+            message.into_bytes(),
             &DocumentEncryptOpts::with_explicit_grants(None, None, true, vec![(&group_id).into()]),
         )
         .await?;
@@ -32,10 +32,10 @@ async fn encrypt_to_group(sdk: &IronOxide) -> Result<DocumentId> {
 
 async fn encrypt_to_user(sdk: &IronOxide, user_id: &UserId) -> Result<DocumentId> {
     // start-snippet{encryptToUser}
-    let message = "This is my secret for a single user.";
+    let message = "This is my secret for a single user.".to_string();
     let encrypted_result = sdk
         .document_encrypt(
-            message.as_bytes(),
+            message.into_bytes(),
             &DocumentEncryptOpts::with_explicit_grants(None, None, true, vec![user_id.into()]),
         )
         .await?;
@@ -47,7 +47,7 @@ async fn encrypt_to_user(sdk: &IronOxide, user_id: &UserId) -> Result<DocumentId
 
 async fn encrypt_with_policy(sdk: &IronOxide) -> Result<DocumentId> {
     // start-snippet{encrypt_with_policy}
-    let message = "this is my secret which has some labels.";
+    let message = "this is my secret which has some labels.".to_string();
     let data_labels = PolicyGrant::new(
         Some(Category::try_from("PII")?),
         Some(Sensitivity::try_from("PRIVATE")?),
@@ -56,7 +56,7 @@ async fn encrypt_with_policy(sdk: &IronOxide) -> Result<DocumentId> {
     );
     let encrypted_result = sdk
         .document_encrypt(
-            message.as_bytes(),
+            message.into_bytes(),
             &DocumentEncryptOpts::with_policy_grants(None, None, data_labels),
         )
         .await?;

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -77,7 +77,7 @@ impl BlockingIronOxide {
     /// See [ironoxide::document::DocumentOps::document_encrypt](trait.DocumentOps.html#tymethod.document_encrypt)
     pub fn document_encrypt(
         &self,
-        document_data: &[u8],
+        document_data: Vec<u8>,
         encrypt_opts: &DocumentEncryptOpts,
     ) -> Result<DocumentEncryptResult> {
         self.runtime
@@ -87,7 +87,7 @@ impl BlockingIronOxide {
     pub fn document_update_bytes(
         &self,
         id: &DocumentId,
-        new_document_data: &[u8],
+        new_document_data: Vec<u8>,
     ) -> Result<DocumentEncryptResult> {
         self.runtime
             .block_on(self.ironoxide.document_update_bytes(id, new_document_data))
@@ -127,7 +127,7 @@ impl BlockingIronOxide {
     /// See [ironoxide::document::advanced::DocumentAdvancedOps::document_encrypt_unmanaged](trait.DocumentAdvancedOps.html#tymethod.document_encrypt_unmanaged)
     pub fn document_encrypt_unmanaged(
         &self,
-        data: &[u8],
+        data: Vec<u8>,
         encrypt_opts: &DocumentEncryptOpts,
     ) -> Result<DocumentEncryptUnmanagedResult> {
         self.runtime.block_on(

--- a/src/crypto/aes.rs
+++ b/src/crypto/aes.rs
@@ -118,7 +118,7 @@ impl From<ring::error::Unspecified> for IronOxideErr {
     }
 }
 
-/// Derive a key from a string password. Returns a tuple of salt that was used as part of the deriviation and the
+/// Derive a key from a string password. Returns a tuple of salt that was used as part of the derivation and the
 /// key, both of which are 32 bytes.
 fn derive_key_from_password(password: &str, salt: [u8; PBKDF2_SALT_LEN]) -> [u8; AES_KEY_LEN] {
     let mut derived_key = [0u8; digest::SHA256_OUTPUT_LEN];
@@ -144,7 +144,7 @@ pub fn encrypt_user_master_key<R: CryptoRng + RngCore>(
     take_lock(rng).deref_mut().fill_bytes(&mut salt);
     let derived_key = derive_key_from_password(password, salt);
 
-    let encrypted_key = encrypt(rng, &user_master_key.to_vec(), derived_key)?;
+    let encrypted_key = encrypt(rng, user_master_key.to_vec(), derived_key)?;
     //Convert the AES encrypted ciphertext vector into a fixed size array so that the
     //EncryptedMasterKey struct is all fixed size values
     let mut master_key_ciphertext = [0u8; ENCRYPTED_KEY_AND_GCM_TAG_LEN];
@@ -200,7 +200,7 @@ impl aead::NonceSequence for SingleUseNonceGenerator {
 /// is a struct which contains the resulting ciphertext and the IV used during encryption.
 pub fn encrypt<R: CryptoRng + RngCore>(
     rng: &Mutex<R>,
-    plaintext: &[u8],
+    mut plaintext: Vec<u8>,
     key: [u8; AES_KEY_LEN],
 ) -> Result<AesEncryptedValue, Unspecified> {
     let algorithm = &aead::AES_256_GCM;
@@ -210,11 +210,10 @@ pub fn encrypt<R: CryptoRng + RngCore>(
         aead::UnboundKey::new(algorithm, &key[..])?,
         SingleUseNonceGenerator::new(iv),
     );
-    //Increase the size of the plaintext vector to fit the GCM auth tag
-    let mut ciphertext = plaintext.to_owned(); // <-- Not good. We're copying the entire plaintext, which could be large.
-    aes_key.seal_in_place_append_tag(aead::Aad::empty(), &mut ciphertext)?;
+    // Increase the size of the plaintext vector to fit the GCM auth tag
+    aes_key.seal_in_place_append_tag(aead::Aad::empty(), &mut plaintext)?;
     Ok(AesEncryptedValue {
-        ciphertext,
+        ciphertext: plaintext,
         aes_iv: iv,
     })
 }
@@ -222,7 +221,7 @@ pub fn encrypt<R: CryptoRng + RngCore>(
 /// Like `encrypt`, just async for convenience
 pub async fn encrypt_async<R: CryptoRng + RngCore>(
     rng: &Mutex<R>,
-    plaintext: &[u8],
+    plaintext: Vec<u8>,
     key: [u8; AES_KEY_LEN],
 ) -> Result<AesEncryptedValue, IronOxideErr> {
     async { encrypt(rng, plaintext, key).map_err(IronOxideErr::from) }.await
@@ -280,7 +279,7 @@ mod tests {
         let mut rng = rand::thread_rng();
         rng.fill_bytes(&mut key);
 
-        let res = encrypt(&Mutex::new(rng), &plaintext, key).unwrap();
+        let res = encrypt(&Mutex::new(rng), plaintext.clone(), key).unwrap();
         assert_eq!(res.aes_iv.len(), 12);
         assert_eq!(
             res.ciphertext.len(),
@@ -295,7 +294,7 @@ mod tests {
         let mut rng = rand::thread_rng();
         rng.fill_bytes(&mut key);
 
-        let mut encrypted_result = encrypt(&Mutex::new(rng), &plaintext, key).unwrap();
+        let mut encrypted_result = encrypt(&Mutex::new(rng), plaintext.clone(), key).unwrap();
 
         let decrypted_plaintext = decrypt(&mut encrypted_result, key).unwrap();
 
@@ -336,7 +335,7 @@ mod tests {
             let rng_ref = a_rng.clone();
             let pt = plaintext.clone();
             threads.push(std::thread::spawn(move || {
-                let _res = encrypt(&rng_ref, &pt, key).unwrap();
+                let _res = encrypt(&rng_ref, pt, key).unwrap();
             }));
         }
 

--- a/src/crypto/aes.rs
+++ b/src/crypto/aes.rs
@@ -235,10 +235,10 @@ pub fn decrypt(
     key: [u8; AES_KEY_LEN],
 ) -> Result<&mut [u8], Unspecified> {
     let mut aes_key = aead::OpeningKey::new(
-        aead::UnboundKey::new(&aead::AES_256_GCM, &key[..])?,
+        aead::UnboundKey::new(&aead::AES_256_GCM, &key)?,
         SingleUseNonceGenerator::new(encrypted_doc.aes_iv),
     );
-    let plaintext = aes_key.open_in_place(aead::Aad::empty(), &mut encrypted_doc.ciphertext[..])?;
+    let plaintext = aes_key.open_in_place(aead::Aad::empty(), &mut encrypted_doc.ciphertext)?;
     Ok(plaintext)
 }
 

--- a/src/document.rs
+++ b/src/document.rs
@@ -154,14 +154,14 @@ pub trait DocumentOps {
     /// # use ironoxide::prelude::*;
     /// # let sdk: IronOxide = unimplemented!();
     /// # use ironoxide::document::DocumentEncryptOpts;
-    /// let data = "secret data".as_bytes();
+    /// let data = "secret data".to_string().into_bytes();
     /// let encrypted = sdk.document_encrypt(data, &DocumentEncryptOpts::default()).await?;
     /// # Ok(())
     /// # }
     /// ```
     async fn document_encrypt(
         &self,
-        document_data: &[u8],
+        document_data: Vec<u8>,
         encrypt_opts: &DocumentEncryptOpts,
     ) -> Result<DocumentEncryptResult>;
 
@@ -262,7 +262,7 @@ pub trait DocumentOps {
     /// # use ironoxide::prelude::*;
     /// # let sdk: IronOxide = unimplemented!();
     /// # let document_id: DocumentId = unimplemented!();
-    /// let new_data = "more secret data".as_bytes();
+    /// let new_data = "more secret data".to_string().into_bytes();
     /// let encrypted = sdk.document_update_bytes(&document_id, new_data).await?;
     /// # Ok(())
     /// # }
@@ -270,7 +270,7 @@ pub trait DocumentOps {
     async fn document_update_bytes(
         &self,
         id: &DocumentId,
-        new_document_data: &[u8],
+        new_document_data: Vec<u8>,
     ) -> Result<DocumentEncryptResult>;
 
     /// Modifies or removes a document's name.
@@ -370,7 +370,7 @@ pub trait DocumentOps {
 impl DocumentOps for crate::IronOxide {
     async fn document_encrypt(
         &self,
-        document_data: &[u8],
+        document_data: Vec<u8>,
         encrypt_opts: &DocumentEncryptOpts,
     ) -> Result<DocumentEncryptResult> {
         let encrypt_opts = encrypt_opts.clone();
@@ -453,7 +453,7 @@ impl DocumentOps for crate::IronOxide {
     async fn document_update_bytes(
         &self,
         id: &DocumentId,
-        new_document_data: &[u8],
+        new_document_data: Vec<u8>,
     ) -> Result<DocumentEncryptResult> {
         add_optional_timeout(
             document_api::document_update_bytes(

--- a/src/document/advanced.rs
+++ b/src/document/advanced.rs
@@ -33,7 +33,7 @@ pub trait DocumentAdvancedOps {
     ///      [DocumentEncryptOpts::default()](../struct.DocumentEncryptOpts.html#method.default).
     async fn document_encrypt_unmanaged(
         &self,
-        data: &[u8],
+        data: Vec<u8>,
         encrypt_opts: &DocumentEncryptOpts,
     ) -> Result<DocumentEncryptUnmanagedResult>;
 
@@ -58,7 +58,7 @@ pub trait DocumentAdvancedOps {
 impl DocumentAdvancedOps for crate::IronOxide {
     async fn document_encrypt_unmanaged(
         &self,
-        data: &[u8],
+        data: Vec<u8>,
         encrypt_opts: &DocumentEncryptOpts,
     ) -> Result<DocumentEncryptUnmanagedResult> {
         let (explicit_users, explicit_groups, grant_to_author, policy_grants) =

--- a/src/internal/document_api.rs
+++ b/src/internal/document_api.rs
@@ -599,10 +599,9 @@ pub async fn encrypt_document<
 ) -> Result<DocumentEncryptResult, IronOxideErr> {
     let (dek, doc_sym_key) = transform::generate_new_doc_key(recrypt);
     let doc_id = document_id.unwrap_or_else(|| DocumentId::goo_id(rng));
-    let pt_bytes = plaintext.to_vec();
 
     let (encrypted_doc, (grants, key_errs)) = try_join!(
-        aes::encrypt_async(rng, &pt_bytes, *doc_sym_key.bytes()),
+        aes::encrypt_async(rng, plaintext.to_vec(), *doc_sym_key.bytes()),
         resolve_keys_for_grants(
             auth,
             config,
@@ -763,10 +762,9 @@ where
 
     let (dek, doc_sym_key) = transform::generate_new_doc_key(recrypt);
     let doc_id = document_id.unwrap_or_else(|| DocumentId::goo_id(rng));
-    let pt_bytes = plaintext.to_vec();
 
     let (encryption_result, (grants, key_errs)) = try_join!(
-        aes::encrypt_async(rng, &pt_bytes, *doc_sym_key.bytes()),
+        aes::encrypt_async(rng, plaintext.to_vec(), *doc_sym_key.bytes()),
         resolve_keys_for_grants(
             auth,
             &config,
@@ -1036,7 +1034,7 @@ pub async fn document_update_bytes<
         device_private_key.recrypt_key(),
     )?;
     Ok(
-        aes::encrypt(rng, &plaintext.to_vec(), *sym_key.bytes()).map(move |encrypted_doc| {
+        aes::encrypt(rng, plaintext.to_vec(), *sym_key.bytes()).map(move |encrypted_doc| {
             let mut encrypted_payload =
                 DocumentHeader::new(document_id.clone(), auth.segment_id()).pack();
             encrypted_payload.0.append(&mut encrypted_doc.bytes());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@
 //! # use ironoxide::prelude::*;
 //! # let sdk: IronOxide = unimplemented!();
 //! use ironoxide::document::DocumentEncryptOpts;
-//! let data = "secret data".as_bytes();
+//! let data = "secret data".to_string().into_bytes();
 //! let encrypted = sdk.document_encrypt(data, &DocumentEncryptOpts::default()).await?;
 //! let encrypted_bytes = encrypted.encrypted_data();
 //! # Ok(())

--- a/src/search.rs
+++ b/src/search.rs
@@ -86,7 +86,7 @@ impl BlindIndexSearchInitialize for IronOxide {
 
         let encrypted_salt = self
             .document_encrypt_unmanaged(
-                &salt,
+                salt.into(),
                 &DocumentEncryptOpts::with_explicit_grants(
                     None,
                     None,

--- a/tests/blocking_ops.rs
+++ b/tests/blocking_ops.rs
@@ -77,11 +77,12 @@ mod integration_tests {
         .into();
         let sdk = ironoxide::blocking::initialize(&device, &Default::default())?;
         let doc = [0u8; 64];
-        let doc_result = sdk.document_encrypt(&doc, &Default::default())?;
+        let doc_result = sdk.document_encrypt(doc.into(), &Default::default())?;
         assert_eq!(doc_result.grants().len(), 1);
         assert_eq!(doc_result.access_errs().len(), 0);
 
-        let doc_unmanaged_result = sdk.document_encrypt_unmanaged(&doc, &Default::default())?;
+        let doc_unmanaged_result =
+            sdk.document_encrypt_unmanaged(doc.into(), &Default::default())?;
         assert_eq!(doc_unmanaged_result.grants().len(), 1);
         assert_eq!(doc_unmanaged_result.access_errs().len(), 0);
 

--- a/tests/group_ops.rs
+++ b/tests/group_ops.rs
@@ -111,7 +111,7 @@ async fn group_rotate_private_key() -> Result<(), IronOxideErr> {
 
     let encrypt_result = creator_sdk
         .document_encrypt(
-            &bytes,
+            bytes.clone(),
             &DocumentEncryptOpts::with_explicit_grants(
                 None,
                 None,

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -118,7 +118,7 @@ async fn user_add_device_after_rotation() -> Result<(), IronOxideErr> {
 
     let encrypt_result = sdk
         .document_encrypt(
-            &bytes,
+            bytes.clone(),
             &DocumentEncryptOpts::with_explicit_grants(None, None, true, vec![]),
         )
         .await?;


### PR DESCRIPTION
PR really has 2 parts, so I broke them into 2 commits you can view separately. I think we should definitely keep 1, but we could decide to not do 2.
1. `crypto::aes::encrypt` now takes `Vec<u8>` plaintext instead of `&[u8]`. The call sites were all already doing `&plaintext.to_vec()`, so they had owned data. And now we don't have to `.to_owned()` when encrypting.
2. Changes our public functions like `document_encrypt()` to take `Vec<u8>` instead of `&[u8]`. Since this is public this would be a breaking change. But essentially if we need owned data, we should take owned data (instead of just internally cloning with `.to_vec()`). It'll instead be up to the caller whether or not they need to clone their data (and I think they frequently won't need to be using their unencrypted_data again after encrypting it).

Closes #3