### PR TITLE
Satisfy clippy

### DIFF
--- a/src/crypto/transform.rs
+++ b/src/crypto/transform.rs
@@ -79,11 +79,10 @@ pub fn encrypt_to_with_key<T, CR: rand::CryptoRng + rand::RngCore>(
 }
 impl From<(WithKey<UserOrGroup>, RecryptErr)> for DocAccessEditErr {
     fn from((user_or_group, err): (WithKey<UserOrGroup>, RecryptErr)) -> Self {
-        match user_or_group {
-            WithKey { id, .. } => DocAccessEditErr::new(
-                id,
-                format!("Access grant failed with error {}", err.to_string()),
-            ),
-        }
+        let WithKey { id, .. } = user_or_group;
+        DocAccessEditErr::new(
+            id,
+            format!("Access grant failed with error {}", err.to_string()),
+        )
     }
 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -329,7 +329,7 @@ pub trait DocumentOps {
     async fn document_grant_access(
         &self,
         document_id: &DocumentId,
-        grant_list: &Vec<UserOrGroup>,
+        grant_list: &[UserOrGroup],
     ) -> Result<DocumentAccessResult>;
 
     /// Revokes decryption access to a document for the provided users and/or groups.
@@ -362,7 +362,7 @@ pub trait DocumentOps {
     async fn document_revoke_access(
         &self,
         document_id: &DocumentId,
-        revoke_list: &Vec<UserOrGroup>,
+        revoke_list: &[UserOrGroup],
     ) -> Result<DocumentAccessResult>;
 }
 
@@ -486,7 +486,7 @@ impl DocumentOps for crate::IronOxide {
     async fn document_grant_access(
         &self,
         id: &DocumentId,
-        grant_list: &Vec<UserOrGroup>,
+        grant_list: &[UserOrGroup],
     ) -> Result<DocumentAccessResult> {
         let (users, groups) = partition_user_or_group(grant_list);
 
@@ -509,7 +509,7 @@ impl DocumentOps for crate::IronOxide {
     async fn document_revoke_access(
         &self,
         id: &DocumentId,
-        revoke_list: &Vec<UserOrGroup>,
+        revoke_list: &[UserOrGroup],
     ) -> Result<DocumentAccessResult> {
         add_optional_timeout(
             document_api::document_revoke_access(self.device.auth(), id, revoke_list),

--- a/src/internal.rs
+++ b/src/internal.rs
@@ -719,7 +719,7 @@ pub(crate) fn take_lock<T>(m: &Mutex<T>) -> MutexGuard<T> {
     m.lock().unwrap_or_else(|e| {
         let error = format!("Error when acquiring lock: {}", e);
         error!("{}", error);
-        panic!(error);
+        panic!("{}", error);
     })
 }
 

--- a/src/internal/document_api.rs
+++ b/src/internal/document_api.rs
@@ -592,8 +592,8 @@ pub async fn encrypt_document<
     document_id: Option<DocumentId>,
     document_name: Option<DocumentName>,
     grant_to_author: bool,
-    user_grants: &Vec<UserId>,
-    group_grants: &Vec<GroupId>,
+    user_grants: &[UserId],
+    group_grants: &[GroupId],
     policy_grant: Option<&PolicyGrant>,
     policy_cache: &PolicyCache,
 ) -> Result<DocumentEncryptResult, IronOxideErr> {
@@ -610,7 +610,7 @@ pub async fn encrypt_document<
             group_grants,
             policy_grant,
             if grant_to_author {
-                Some(&user_master_pub_key)
+                Some(user_master_pub_key)
             } else {
                 None
             },
@@ -654,8 +654,8 @@ type UserMasterPublicKey = PublicKey;
 async fn resolve_keys_for_grants(
     auth: &RequestAuth,
     config: &IronOxideConfig,
-    user_grants: &Vec<UserId>,
-    group_grants: &Vec<GroupId>,
+    user_grants: &[UserId],
+    group_grants: &[GroupId],
     policy_grant: Option<&PolicyGrant>,
     maybe_user_master_pub_key: Option<&UserMasterPublicKey>,
     policy_cache: &PolicyCache,
@@ -750,8 +750,8 @@ pub async fn encrypt_document_unmanaged<R1, R2>(
     plaintext: &[u8],
     document_id: Option<DocumentId>,
     grant_to_author: bool,
-    user_grants: &Vec<UserId>,
-    group_grants: &Vec<GroupId>,
+    user_grants: &[UserId],
+    group_grants: &[GroupId],
     policy_grant: Option<&PolicyGrant>,
 ) -> Result<DocumentEncryptUnmanagedResult, IronOxideErr>
 where
@@ -774,7 +774,7 @@ where
             group_grants,
             policy_grant,
             if grant_to_author {
-                Some(&user_master_pub_key)
+                Some(user_master_pub_key)
             } else {
                 None
             },
@@ -979,10 +979,12 @@ impl EncryptedDoc {
             .collect();
         let proto_edek_vec = proto_edek_vec_results?;
 
-        let mut proto_edeks = EncryptedDeksP::default();
-        proto_edeks.edeks = RepeatedField::from_vec(proto_edek_vec);
-        proto_edeks.documentId = self.header.document_id.id().into();
-        proto_edeks.segmentId = self.header.segment_id as i32; // okay since the ironcore-ws defines this to be an i32
+        let proto_edeks = EncryptedDeksP {
+            edeks: RepeatedField::from_vec(proto_edek_vec),
+            documentId: self.header.document_id.id().into(),
+            segmentId: self.header.segment_id as i32, // okay since the ironcore-ws defines this to be an i32
+            ..Default::default()
+        };
 
         let edek_bytes = proto_edeks.write_to_bytes()?;
         Ok(edek_bytes)
@@ -1104,7 +1106,7 @@ pub async fn decrypt_document_unmanaged<CR: rand::CryptoRng + rand::RngCore>(
                 parse_document_parts(encrypted_doc)?,
             ))
         },
-        requests::edek_transform::edek_transform(&auth, encrypted_deks,)
+        requests::edek_transform::edek_transform(auth, encrypted_deks,)
     )?;
 
     edeks_and_header_match_or_err(&proto_edeks, &doc_meta)?;
@@ -1164,8 +1166,8 @@ pub async fn document_grant_access<CR: rand::CryptoRng + rand::RngCore>(
     id: &DocumentId,
     user_master_pub_key: &PublicKey,
     priv_device_key: &PrivateKey,
-    user_grants: &Vec<UserId>,
-    group_grants: &Vec<GroupId>,
+    user_grants: &[UserId],
+    group_grants: &[GroupId],
 ) -> Result<DocumentAccessResult, IronOxideErr> {
     let (doc_meta, users, groups) = try_join!(
         document_get_metadata(auth, id),
@@ -1211,7 +1213,7 @@ pub async fn document_grant_access<CR: rand::CryptoRng + rand::RngCore>(
 pub async fn document_revoke_access(
     auth: &RequestAuth,
     id: &DocumentId,
-    revoke_list: &Vec<UserOrGroup>,
+    revoke_list: &[UserOrGroup],
 ) -> Result<DocumentAccessResult, IronOxideErr> {
     use requests::document_access::{self, resp};
 

--- a/src/internal/document_api/requests.rs
+++ b/src/internal/document_api/requests.rs
@@ -512,7 +512,8 @@ mod tests {
         let result = serde_json::to_string(&item).unwrap();
         assert!(
             result.contains("\"fromGroup\""),
-            format!("{} should contain fromGroup", result)
+            "{} should contain fromGroup",
+            result
         );
         let de_result = serde_json::from_str(&result).unwrap();
         assert_eq!(item, de_result)

--- a/src/internal/group_api.rs
+++ b/src/internal/group_api.rs
@@ -72,7 +72,7 @@ impl GroupId {
     }
 }
 impl recrypt::api::Hashable for GroupId {
-    fn to_bytes(self: &Self) -> Vec<u8> {
+    fn to_bytes(&self) -> Vec<u8> {
         self.0.as_bytes().to_vec()
     }
 }
@@ -364,7 +364,7 @@ impl GroupAccessEditResult {
 // List all of the groups that the requesting user is either a member or admin of
 pub async fn list(
     auth: &RequestAuth,
-    ids: Option<&Vec<GroupId>>,
+    ids: Option<&[GroupId]>,
 ) -> Result<GroupListResult, IronOxideErr> {
     let GroupListResponse { result } = match ids {
         Some(group_ids) => requests::group_list::group_limited_list_request(auth, group_ids).await,
@@ -382,14 +382,14 @@ pub async fn list(
 /// Calling this with an empty `groups` list will not result in a call to the server.
 pub(crate) async fn get_group_keys(
     auth: &RequestAuth,
-    groups: &Vec<GroupId>,
+    groups: &[GroupId],
 ) -> Result<(Vec<GroupId>, Vec<WithKey<GroupId>>), IronOxideErr> {
     // if there aren't any groups in the list, just return with empty results
     if groups.is_empty() {
         return Ok((vec![], vec![]));
     }
 
-    let cloned_groups: Vec<GroupId> = groups.clone();
+    let cloned_groups: Vec<GroupId> = groups.to_vec();
     let GroupListResult { result } = list(auth, Some(groups)).await?;
     let ids_with_keys =
         result
@@ -494,7 +494,7 @@ pub async fn group_create<CR: rand::CryptoRng + rand::RngCore>(
     owner: Option<UserId>,
     admins: Vec1<UserId>,
     members: Vec<UserId>,
-    users_to_lookup: &Vec<UserId>,
+    users_to_lookup: &[UserId],
     needs_rotation: bool,
 ) -> Result<GroupCreateResult, IronOxideErr> {
     let user_ids_and_keys = user_api::user_key_list(auth, users_to_lookup).await?;
@@ -628,8 +628,7 @@ fn generate_aug_and_admins<CR: rand::CryptoRng + rand::RngCore>(
     );
     errors
         .into_iter()
-        .map(|(_, e)| Err(e.into()))
-        .collect::<Result<(), IronOxideErr>>()?;
+        .try_for_each(|(_, e)| Err::<(), IronOxideErr>(e.into()))?;
     Ok((aug_factor.into(), updated_group_admins))
 }
 
@@ -707,7 +706,7 @@ pub async fn group_add_members<CR: rand::CryptoRng + rand::RngCore>(
     auth: &RequestAuth,
     device_private_key: &PrivateKey,
     group_id: &GroupId,
-    users: &Vec<UserId>,
+    users: &[UserId],
 ) -> Result<GroupAccessEditResult, IronOxideErr> {
     let (group_get, (mut acc_fails, successes)) =
         try_join!(get_metadata(auth, group_id), get_user_keys(auth, users))?;
@@ -769,7 +768,7 @@ pub async fn group_add_admins<CR: rand::CryptoRng + rand::RngCore>(
     auth: &RequestAuth,
     device_private_key: &PrivateKey,
     group_id: &GroupId,
-    users: &Vec<UserId>,
+    users: &[UserId],
 ) -> Result<GroupAccessEditResult, IronOxideErr> {
     let (group_get, (mut acc_fails, successes)) =
         try_join!(get_metadata(auth, group_id), get_user_keys(auth, users))?;
@@ -821,7 +820,7 @@ pub async fn group_add_admins<CR: rand::CryptoRng + rand::RngCore>(
 ///This is a thin wrapper that's just mapping the errors into the type we need for add member and add admin
 async fn get_user_keys(
     auth: &RequestAuth,
-    users: &Vec<UserId>,
+    users: &[UserId],
 ) -> Result<(Vec<GroupAccessEditErr>, Vec<WithKey<UserId>>), IronOxideErr> {
     let (failed_ids, succeeded_ids) = user_api::get_user_keys(auth, users).await?;
     let failed_ids_result = failed_ids
@@ -868,7 +867,7 @@ pub async fn update_group_name(
 pub async fn group_remove_entity(
     auth: &RequestAuth,
     id: &GroupId,
-    users: &Vec<UserId>,
+    users: &[UserId],
     entity_type: GroupEntity,
 ) -> Result<GroupAccessEditResult, IronOxideErr> {
     let GroupUserEditResponse {

--- a/src/internal/group_api/requests.rs
+++ b/src/internal/group_api/requests.rs
@@ -195,7 +195,7 @@ pub mod group_list {
     //List a specific set of groups given a list of group IDs
     pub async fn group_limited_list_request(
         auth: &RequestAuth,
-        groups: &Vec<GroupId>,
+        groups: &[GroupId],
     ) -> Result<GroupListResponse, IronOxideErr> {
         let group_ids: Vec<&str> = groups.iter().map(GroupId::id).collect();
         auth.request
@@ -462,7 +462,7 @@ pub mod group_remove_entity {
     pub async fn remove_entity_request(
         auth: &RequestAuth,
         group_id: &GroupId,
-        user_ids: &Vec<UserId>,
+        user_ids: &[UserId],
         entity_type: GroupEntity,
     ) -> Result<GroupUserEditResponse, IronOxideErr> {
         let removed_users = user_ids
@@ -522,11 +522,13 @@ mod tests {
         let result = serde_json::to_string(&item).unwrap();
         assert!(
             result.contains("\"admin\""),
-            format!("{} should contain admin", result)
+            "{} should contain admin",
+            result
         );
         assert!(
             result.contains("\"member\""),
-            format!("{} should contain member", result)
+            "{} should contain member",
+            result
         );
         let de_result = serde_json::from_str(&result).unwrap();
         assert_eq!(item, de_result)

--- a/src/internal/rest.rs
+++ b/src/internal/rest.rs
@@ -107,6 +107,7 @@ pub fn url_encode(token: &str) -> PercentEncodedString {
     PercentEncodedString(percent_encoding::utf8_percent_encode(token, ICL_ENCODE_SET).to_string())
 }
 
+#[allow(clippy::large_enum_variant)]
 ///Enum representing all the ways that authorization can be done for the IronCoreRequest.
 pub enum Authorization<'a> {
     JwtAuth(&'a Jwt),

--- a/src/internal/user_api/requests.rs
+++ b/src/internal/user_api/requests.rs
@@ -286,7 +286,7 @@ pub mod user_key_list {
 
     pub async fn user_key_list_request(
         auth: &RequestAuth,
-        users: &Vec<UserId>,
+        users: &[UserId],
     ) -> Result<UserKeyListResponse, IronOxideErr> {
         let user_ids: Vec<&str> = users.iter().map(UserId::id).collect();
         if !user_ids.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,10 +147,12 @@
 //! # }
 //! ```
 
-// required by quick_error or IronOxideErr
-#![recursion_limit = "128"]
-// required as of rust 1.46.0
-#![type_length_limit = "2000000"]
+#![allow(clippy::too_many_arguments)]
+#![allow(clippy::type_complexity)]
+// // required by quick_error or IronOxideErr
+// #![recursion_limit = "128"]
+// // required as of rust 1.46.0
+// #![type_length_limit = "2000000"]
 
 // include generated proto code as a proto module
 include!(concat!(env!("OUT_DIR"), "/transform.rs"));
@@ -358,7 +360,7 @@ pub async fn initialize(
 /// Finds the groups that the caller is an admin of that need rotation and
 /// forms an InitAndRotationCheck from the user/groups needing rotation.
 fn check_groups_and_collect_rotation<T>(
-    groups: &Vec<internal::group_api::GroupMetaResult>,
+    groups: &[internal::group_api::GroupMetaResult],
     user_needs_rotation: bool,
     account_id: UserId,
     ironoxide: T,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,9 +150,9 @@
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
 // // required by quick_error or IronOxideErr
-// #![recursion_limit = "128"]
+#![recursion_limit = "128"]
 // // required as of rust 1.46.0
-// #![type_length_limit = "2000000"]
+#![type_length_limit = "2000000"]
 
 // include generated proto code as a proto module
 include!(concat!(env!("OUT_DIR"), "/transform.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,9 +149,9 @@
 
 #![allow(clippy::too_many_arguments)]
 #![allow(clippy::type_complexity)]
-// // required by quick_error or IronOxideErr
+// required by quick_error or IronOxideErr
 #![recursion_limit = "128"]
-// // required as of rust 1.46.0
+// required as of rust 1.46.0
 #![type_length_limit = "2000000"]
 
 // include generated proto code as a proto module


### PR DESCRIPTION
A few lints were just silenced: too many arguments, complex return type, and large enum size difference.
This did lead to some changes in our public API, so we'll have to decide if we're okay with that (changing anywhere we take `&Vec<_>` to `&[_]`).
With this satisfied, we could consider adding the clippy workflow to this repo's CI