### PR TITLE
Rust 2021, dependency upgrades

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
             features: default
           # MSRV
           - os: ubuntu-18.04
-            toolchain: 1.41.1
+            toolchain: 1.56.0
             features: default
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.27.0 (Unreleased)
+
+- [[#248](https://github.com/IronCoreLabs/ironoxide/pull/248)]
+  - Bump MSRV to 1.56.0
+  - Update to recrypt 0.13
+  - Update to rand 0.8
+  - Update to rand_chacha 0.3
+  - Update to ironcore-search-helpers 0.2
+
 ## 0.26.0
 
 - [[#243](https://github.com/IronCoreLabs/ironoxide/pull/243)] Add `#[non_exhaustive]` to IronOxideErr.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironoxide"
-version = "0.26.0"
+version = "0.27.0"
 authors = [ "IronCore Labs <info@ironcorelabs.com>" ]
 readme = "README.md"
 license = "AGPL-3.0-only"
@@ -9,7 +9,8 @@ documentation = "https://docs.rs/ironoxide"
 categories = [ "cryptography" ]
 keywords = [ "cryptography", "proxy-re-encryption", "PRE", "ECC", "transform-encryption" ]
 description = "A pure-Rust SDK for accessing IronCore's privacy platform"
-edition = "2018"
+edition = "2021"
+rust-version = "1.56.0"
 
 [dependencies]
 async-trait = "0.1.21"
@@ -20,7 +21,7 @@ chrono = { version = "0.4", features = [ "serde" ] }
 dashmap = "4"
 futures = "0.3.1"
 hex = "0.4"
-ironcore-search-helpers = { version = "0.1.2", optional = true }
+ironcore-search-helpers = { version = "0.2", optional = true }
 itertools = "0.10"
 jsonwebtoken = "7.2"
 lazy_static = "1.4"
@@ -28,9 +29,9 @@ log = "0.4"
 percent-encoding = "2.1"
 protobuf = { version = "2.20", features = [ "with-bytes" ] }
 quick-error = "2"
-rand = "0.7"
-rand_chacha = "0.2.2"
-recrypt = "0.12"
+rand = "0.8"
+rand_chacha = "0.3"
+recrypt = "0.13"
 regex = "1.4"
 reqwest = { version = "0.11", features = [ "json" ], default-features = false }
 ring = { version = "0.16", features = [ "std" ] }

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -273,7 +273,7 @@ impl BlockingIronOxide {
 
 /// Creates a tokio runtime with the default number of core threads (num of cores on a machine)
 fn create_runtime() -> tokio::runtime::Runtime {
-    tokio::runtime::Builder::new_multi_thread()
+    tokio::runtime::Builder::new_current_thread()
         .enable_all() // enable both I/O and time drivers
         .build()
         .expect("tokio runtime failed to initialize")

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -271,7 +271,7 @@ impl BlockingIronOxide {
     }
 }
 
-/// Creates a tokio runtime with the default number of core threads (num of cores on a machine)
+/// Creates a tokio runtime on the current thread
 fn create_runtime() -> tokio::runtime::Runtime {
     tokio::runtime::Builder::new_current_thread()
         .enable_all() // enable both I/O and time drivers


### PR DESCRIPTION
  - Update to recrypt 0.13
  - Update to rand 0.8
  - Update to rand_chacha 0.3
  - Update to ironcore-search-helpers 0.2