### PR TITLE
Only run security audit on schedule

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -1,12 +1,8 @@
 name: Daily runs
 
-# Run daily and also when Cargo.toml changes
 on:
   schedule:
     - cron: "0 14 * * *" # Daily at 2pm UTC
-  push:
-    paths:
-      - "**/Cargo.toml"
 
 jobs:
   security-audit:


### PR DESCRIPTION
We're inconsistent with this across repos, but this makes the triggers match our others. This will make this no longer run on PRs (making it look like CI is failing when it's just a previously-known dependency deprecation).