### PR TITLE
Implement Hash for Jwt

### DIFF
--- a/src/internal/user_api.rs
+++ b/src/internal/user_api.rs
@@ -305,7 +305,7 @@ pub struct JwtClaims {
 ///
 /// Must be either ES256 or RS256 and have a payload similar to [JwtClaims](struct.JwtClaims.html), but could be
 /// generated from an external source.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Hash)]
 pub struct Jwt {
     jwt: String,
     header: jsonwebtoken::Header,


### PR DESCRIPTION
This was removed in v0.27.0 due to a regression in `jsonwebtoken`.