### PR TITLE
Remove the daily security audit.

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -5,15 +5,6 @@ on:
     - cron: "0 14 * * *" # Daily at 2pm UTC
 
 jobs:
-  security-audit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Run audit checker
-        uses: actions-rs/audit-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This is obsoleted by Dependabot.