### PR TITLE
Use global policy cache in the unmanaged case as well.

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 profile = "default"
 channel = "1.73.0"
+components = ["rust-src", "rust-analyzer"]

--- a/src/document/advanced.rs
+++ b/src/document/advanced.rs
@@ -91,6 +91,7 @@ impl DocumentAdvancedOps for crate::IronOxide {
                 &explicit_users,
                 &explicit_groups,
                 policy_grants,
+                &self.policy_eval_cache,
             ),
             self.config.sdk_operation_timeout,
             SdkOperation::DocumentEncryptUnmanaged,

--- a/src/internal/document_api.rs
+++ b/src/internal/document_api.rs
@@ -752,12 +752,12 @@ pub async fn encrypt_document_unmanaged<R1, R2>(
     user_grants: &[UserId],
     group_grants: &[GroupId],
     policy_grant: Option<&PolicyGrant>,
+    policy_cache: &PolicyCache,
 ) -> Result<DocumentEncryptUnmanagedResult, IronOxideErr>
 where
     R1: rand::CryptoRng + rand::RngCore,
     R2: rand::CryptoRng + rand::RngCore,
 {
-    let policy_cache = dashmap::DashMap::new();
     let config = IronOxideConfig::default();
 
     let (dek, doc_sym_key) = transform::generate_new_doc_key(recrypt);

--- a/tests/document_ops.rs
+++ b/tests/document_ops.rs
@@ -633,8 +633,6 @@ async fn doc_encrypt_decrypt_roundtrip() -> Result<(), IronOxideErr> {
 
 #[tokio::test]
 async fn doc_decrypt_unmanaged_no_access() -> Result<(), IronOxideErr> {
-    use std::borrow::Borrow;
-
     let sdk = initialize_sdk().await?;
 
     let user2 = create_second_user().await;
@@ -647,7 +645,7 @@ async fn doc_decrypt_unmanaged_no_access() -> Result<(), IronOxideErr> {
                 Some(create_id_all_classes("").try_into()?),
                 None,
                 false,
-                vec![user2.account_id().borrow().into()],
+                vec![user2.account_id().into()],
             ),
         )
         .await?;


### PR DESCRIPTION
I verified the change by hacking in the tests. Without using timing specific tests, it's not easy to see that it's working, but I did manually verify it.

If we have any ideas about ways to test for it, lmk. 