### PR TITLE
Fix null parameters in UserUpdateReq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
-## 4.4.0
+## 4.4.1
 
-- [[377](https://github.com/IronCoreLabs/ironoxide/pull/377)]
+- [[#378](https://github.com/IronCoreLabs/ironoxide/pull/378)] Fix an issue where calling `user_disable_self` would update the user's private key.
+
+## 4.4.0 (yanked)
+
+- [[#377](https://github.com/IronCoreLabs/ironoxide/pull/377)]
   - Add `user_disable_self` which a user can call to disable their account. Disabled users can still be members of groups but will be unable to call SDK functions.
   - Add `user_update_status` which uses a JWT to enable or disable a user.
 

--- a/src/internal/user_api/requests.rs
+++ b/src/internal/user_api/requests.rs
@@ -292,7 +292,9 @@ pub mod user_update {
     #[derive(Debug, Serialize)]
     #[serde(rename_all = "camelCase")]
     struct UserUpdateReq {
+        #[serde(skip_serializing_if = "Option::is_none")]
         user_private_key: Option<EncryptedPrivateKey>,
+        #[serde(skip_serializing_if = "Option::is_none")]
         status: Option<UserStatus>,
     }
 

--- a/tests/user_ops.rs
+++ b/tests/user_ops.rs
@@ -345,6 +345,31 @@ async fn user_disable_self_works() -> Result<()> {
 }
 
 #[tokio::test]
+async fn user_disable_self_roundtrips() -> Result<()> {
+    let account_id: UserId = create_id_all_classes("").try_into()?;
+    let jwt = gen_jwt(Some(account_id.id())).0;
+    IronOxide::user_create(&jwt, USER_PASSWORD, &Default::default(), None).await?;
+
+    let device: DeviceContext = IronOxide::generate_new_device(
+        &gen_jwt(Some(account_id.id())).0,
+        USER_PASSWORD,
+        &Default::default(),
+        None,
+    )
+    .await?
+    .into();
+
+    let sdk = ironoxide::initialize(&device, &Default::default()).await?;
+
+    sdk.user_disable_self().await?;
+    let enable_result = IronOxide::user_update_status(&jwt, UserStatus::Enabled, None).await?;
+    assert_eq!(enable_result.status(), UserStatus::Enabled);
+    let disable_result = sdk.user_disable_self().await?;
+    assert_eq!(disable_result.status(), UserStatus::Disabled);
+    Ok(())
+}
+
+#[tokio::test]
 async fn generate_device_with_timeout() -> Result<()> {
     let result = IronOxide::generate_new_device(
         &common::gen_jwt(None).0,


### PR DESCRIPTION
Existing struct serializes on user_disable_self to 
```json
{
  "status": 0,
  "userPrivateKey": null
}
```
which the server then acts on by setting the user's private key to NULL.

This change will make it serialize to 
```json
{
  "status": 0
}
```
which will make the server leave the user's private key unchanged.